### PR TITLE
Remove slack notification for successful test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches: [ main ]
-  workflow_call:
 
 jobs:
   scan_ruby:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -46,7 +46,7 @@ jobs:
           if_mention: failure,cancelled
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()
+        if: failure()
   deploy:
     name: Deploy to Staging
     needs: test

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -39,14 +39,13 @@ jobs:
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3
+        if: failure()
         with:
           text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
           status: ${{ job.status }}
           fields: message,commit,author,eventName,ref,workflow,job,took
-          if_mention: failure,cancelled
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure()
   deploy:
     name: Deploy to Staging
     needs: test


### PR DESCRIPTION
## What was done?
Only send slack message when there is a failure.