### PR TITLE
Create workflow run dependency for deploy to staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   scan_ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Run Linter and Tests
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,13 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+      - name: Send Slack notification on failure
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
+          status: ${{ job.status }}
+          fields: message,commit,author,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    workflows: [ "Run Linter and Tests" ]
+    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
     types: [ completed ]
+    branches: [ main ]
 
 jobs:
   notify_on_slack:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -9,18 +9,6 @@ on:
     branches: [ main ]
 
 jobs:
-  notify_on_slack:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Slack notification on failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
-          status: ${{ job.status }}
-          fields: message,commit,author,eventName,ref,workflow,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   deploy:
     name: Deploy to Staging
     needs: test
@@ -73,3 +61,13 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
             -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"environment\": \"$environment\", \"config\": \"$config\"}}"
+
+      - name: Notify deploy failure on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging test failed ${{ job.status }}"
+          status: ${{ job.status }}
+          fields: message,commit,author,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
+    workflows: [ "Run Linter and Tests" ]
     types: [ completed ]
-    branches: [ main ]
 
 jobs:
   notify_on_slack:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,40 +4,17 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    inputs: { }
+    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
+    types: [ completed ]
+    branches: [ main ]
 
 jobs:
-  test:
+  notify_on_slack:
     runs-on: ubuntu-latest
     steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config google-chrome-stable
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: .ruby-version
-          bundler-cache: true
-
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-        run: bin/rails db:test:prepare test test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
-
-      - name: Slack Notification
+      - name: Send Slack notification on failure
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}  # Check if the first workflow failed
         uses: 8398a7/action-slack@v3
-        if: failure()
         with:
           text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
           status: ${{ job.status }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy to Staging
     needs: test
     runs-on: ubuntu-latest
@@ -66,7 +67,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         if: failure()
         with:
-          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging test failed ${{ job.status }}"
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging deploy failed ${{ job.status }}"
           status: ${{ job.status }}
           fields: message,commit,author,eventName,ref,workflow,job,took
         env:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
+    workflows: [ "Run Linter and Tests" ]
     types: [ completed ]
     branches: [ main ]
 
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification on failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}  # Check if the first workflow failed
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         uses: 8398a7/action-slack@v3
         with:
           text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/FYST-2132

This is a test to see if we can run the CI and Linter & then run the deploy to staging after using `workflow_dispatch`. It could _not_ work. :/ But I don’t know another way to test apart from merging into main.