### PR TITLE
Remove double slack notification on failure of tests on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   scan_ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Run Linter and Tests
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,3 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
-
-      - name: Send Slack notification on failure
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
-          status: ${{ job.status }}
-          fields: message,commit,author,eventName,ref,workflow,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,13 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+      - name: Send Slack notification on failure
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: 8398a7/action-slack@v3
+        with:
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
+          status: ${{ job.status }}
+          fields: message,commit,author,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -9,80 +9,79 @@ on:
     branches: [ main ]
 
 jobs:
-  deploy:
+  on-success:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       ECR_REPOSITORY: pya-staging-web
       IMAGE_TAG: ${{ github.sha }}
-    on-success:
-      name: Deploy to Staging
-      runs-on: ubuntu-latest
-      if: ${{ github.event.workflow_run.conclusion == 'success' }}
-      steps:
-        - run: echo 'The triggering workflow passed'
+    steps:
+      - run: echo 'The triggering workflow passed'
 
-        - name: Check out code
-          uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-        - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@v4
-          with:
-            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-            aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-            aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+          aws-region: us-east-1
 
-        - name: Log in to Amazon ECR
-          id: login-ecr
-          uses: aws-actions/amazon-ecr-login@v2
-        - name: Build and push Docker image
-          env:
-            ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          run: |
-            docker build -t 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}} --platform linux/amd64 .
-            docker push 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}}
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push Docker image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}} --platform linux/amd64 .
+          docker push 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}}
 
-        - name: Update SSM Version Parameter
-          run: |
-            echo "tag:$IMAGE_TAG"
-            aws ssm put-parameter \
-              --name  /pya/staging/web/version \
-              --value "$IMAGE_TAG" \
-              --overwrite
+      - name: Update SSM Version Parameter
+        run: |
+          echo "tag:$IMAGE_TAG"
+          aws ssm put-parameter \
+            --name  /pya/staging/web/version \
+            --value "$IMAGE_TAG" \
+            --overwrite
 
-        - name: Trigger infrastructure deployment
-          run: |
-            # Set the required variables
-            repo_owner="codeforamerica"
-            repo_name="tax-benefits-backend"
-            event_type="deploy"
-            environment="pya-nonprod"
-            config="staging.pya.fileyourstatetaxes.org"
-            curl -L \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer ${{ secrets.STAGING_DEPLOY_PAT }}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-              -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"environment\": \"$environment\", \"config\": \"$config\"}}"
+      - name: Trigger infrastructure deployment
+        run: |
+          # Set the required variables
+          repo_owner="codeforamerica"
+          repo_name="tax-benefits-backend"
+          event_type="deploy"
+          environment="pya-nonprod"
+          config="staging.pya.fileyourstatetaxes.org"
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.STAGING_DEPLOY_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"environment\": \"$environment\", \"config\": \"$config\"}}"
 
-        - name: Notify deploy failure on Slack
-          uses: 8398a7/action-slack@v3
-          if: failure()
-          with:
-            text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging deploy failed ${{ job.status }}"
-            status: ${{ job.status }}
-            fields: message,commit,author,eventName,ref,workflow,job,took
-          env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Notify deploy failure on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging deploy failed ${{ job.status }}"
+          status: ${{ job.status }}
+          fields: message,commit,author,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-    on-failure:
-      runs-on: ubuntu-latest
-      if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-      steps:
-        - name: Send Slack notification on failure
-          uses: 8398a7/action-slack@v3
-          with:
-            text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
-            status: ${{ job.status }}
-            fields: message,commit,author,eventName,ref,workflow,job,took
-          env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Send Slack notification on failure
+        uses: 8398a7/action-slack@v3
+        with:
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
+          status: ${{ job.status }}
+          fields: message,commit,author,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    workflows: [ "Run Linter and Tests" ]
+    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
     types: [ completed ]
+    branches: [ main ]
 
 jobs:
   notify_on_slack:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -9,18 +9,6 @@ on:
     branches: [ main ]
 
 jobs:
-  notify_on_slack:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Slack notification on failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
-          status: ${{ job.status }}
-          fields: message,commit,author,eventName,ref,workflow,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   deploy:
     name: Deploy to Staging
     needs: test
@@ -73,3 +61,13 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
             -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"environment\": \"$environment\", \"config\": \"$config\"}}"
+
+      - name: Notify deploy failure on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure()
+        with:
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging test failed ${{ job.status }}"
+          status: ${{ job.status }}
+          fields: message,commit,author,eventName,ref,workflow,job,took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
+    workflows: [ "Run Linter and Tests" ]
     types: [ completed ]
-    branches: [ main ]
 
 jobs:
   notify_on_slack:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,40 +4,17 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    inputs: { }
+    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
+    types: [ completed ]
+    branches: [ main ]
 
 jobs:
-  test:
+  notify_on_slack:
     runs-on: ubuntu-latest
     steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libyaml-dev pkg-config google-chrome-stable
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: .ruby-version
-          bundler-cache: true
-
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-        run: bin/rails db:test:prepare test test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
-
-      - name: Slack Notification
+      - name: Send Slack notification on failure
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}  # Check if the first workflow failed
         uses: 8398a7/action-slack@v3
-        if: failure()
         with:
           text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
           status: ${{ job.status }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -10,65 +10,73 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    name: Deploy to Staging
-    needs: test
-    runs-on: ubuntu-latest
-    env:
-      ECR_REPOSITORY: pya-staging-web
-      IMAGE_TAG: ${{ github.sha }}
+    on-success:
+      name: Deploy to Staging
+      runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
+      steps:
+        - run: echo 'The triggering workflow passed'
+        - name: Check out code
+          uses: actions/checkout@v4
 
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+        - name: Configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@v4
+          with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
+            aws-region: us-east-1
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
+        - name: Log in to Amazon ECR
+          id: login-ecr
+          uses: aws-actions/amazon-ecr-login@v2
+        - name: Build and push Docker image
+          env:
+            ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          run: |
+            docker build -t 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}} --platform linux/amd64 .
+            docker push 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}}
 
-      - name: Log in to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Build and push Docker image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker build -t 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}} --platform linux/amd64 .
-          docker push 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}}
+        - name: Update SSM Version Parameter
+          run: |
+            echo "tag:$IMAGE_TAG"
+            aws ssm put-parameter \
+              --name  /pya/staging/web/version \
+              --value "$IMAGE_TAG" \
+              --overwrite
 
-      - name: Update SSM Version Parameter
-        run: |
-          echo "tag:$IMAGE_TAG"
-          aws ssm put-parameter \
-            --name  /pya/staging/web/version \
-            --value "$IMAGE_TAG" \
-            --overwrite
-
-      - name: Trigger infrastructure deployment
-        run: |
-          # Set the required variables
-          repo_owner="codeforamerica"
-          repo_name="tax-benefits-backend"
-          event_type="deploy"
-          environment="pya-nonprod"
-          config="staging.pya.fileyourstatetaxes.org"
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.STAGING_DEPLOY_PAT }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"environment\": \"$environment\", \"config\": \"$config\"}}"
-
-      - name: Notify deploy failure on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure()
-        with:
-          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging deploy failed ${{ job.status }}"
-          status: ${{ job.status }}
-          fields: message,commit,author,eventName,ref,workflow,job,took
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        - name: Trigger infrastructure deployment
+          run: |
+            # Set the required variables
+            repo_owner="codeforamerica"
+            repo_name="tax-benefits-backend"
+            event_type="deploy"
+            environment="pya-nonprod"
+            config="staging.pya.fileyourstatetaxes.org"
+            curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.STAGING_DEPLOY_PAT }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+              -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"environment\": \"$environment\", \"config\": \"$config\"}}"
+        - name: Notify deploy failure on Slack
+          uses: 8398a7/action-slack@v3
+          if: failure()
+          with:
+            text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging deploy failed ${{ job.status }}"
+            status: ${{ job.status }}
+            fields: message,commit,author,eventName,ref,workflow,job,took
+          env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    on-failure:
+      runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+      steps:
+        - name: Send Slack notification on failure
+          uses: 8398a7/action-slack@v3
+          with:
+            text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"
+            status: ${{ job.status }}
+            fields: message,commit,author,eventName,ref,workflow,job,took
+          env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,8 +1,6 @@
 name: Deploy to AWS Staging
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
     workflows: [ "Run Linter and Tests" ]
     types: [ completed ]

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,7 +1,7 @@
 name: Deploy to AWS Staging
 
 on:
-  workflow_dispatch:
+  workflow_run:
     workflows: [ "Run Linter and Tests" ]
     types: [ completed ]
     branches: [ main ]

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy to Staging
     needs: test
     runs-on: ubuntu-latest
@@ -66,7 +67,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         if: failure()
         with:
-          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging test failed ${{ job.status }}"
+          text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA staging deploy failed ${{ job.status }}"
           status: ${{ job.status }}
           fields: message,commit,author,eventName,ref,workflow,job,took
         env:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-    workflows: [ "Run Linter and Tests" ] # or "ci" whatever we name the workflow
+    workflows: [ "Run Linter and Tests" ]
     types: [ completed ]
     branches: [ main ]
 
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification on failure
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}  # Check if the first workflow failed
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
         uses: 8398a7/action-slack@v3
         with:
           text: "<!subteam^S06P99RGJDS> <@U07QATMB6SW> <@U07Q99GPBK8> <@U07Q39HFLBG> PYA test suite ${{ job.status }} :sob:"

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - run: echo 'The triggering workflow passed'
 
+      - run: echo 'Starting the staging deploy'
+
       - name: Check out code
         uses: actions/checkout@v4
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,0 @@
-class PagesController < ApplicationController
-  def home
-  end
-
-  def first_page
-  end
-end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
-    get first_page_url
+    # get first_page_url
     assert_response :success
   end
 end


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/FYST-2132


- accidentally left in slack notifications now covered in `on-failure` block of `deploy-to-staging.yml` from #20 
- introducing an error to test out pipeline