### PR TITLE
[FYST-2133] Make the deploys run serially instead of concurrently (fix indentation)

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -5,9 +5,10 @@ on:
     workflows: [ "Run Linter and Tests" ]
     types: [ completed ]
     branches: [ main ]
-  concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   on-success:


### PR DESCRIPTION
Follow up to https://github.com/codeforamerica/pya/pull/25 -- [indentation was off so the workflow failed 😢](https://github.com/codeforamerica/pya/actions/runs/15690534221) 
I couldn't test the workflow on the branch, should be good now