### PR TITLE
[FYST-2131] Define the environment for staging deploy

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   on-success:
+    environment: staging
     name: Deploy to Staging
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- e.g. https://codeforamerica.atlassian.net/browse/FYST-2131
## Is PM acceptance required? (delete one)
- No - merge after code review approval

I moved the secrets from repository secrets to env-specific secrets. In order to reference them correctly, I believe I have to define  the `environment` of the job. I only define it within the `on-success` job since that's the job that needs the AWS credentials. I'm going to continue the work to define the deploy job, but wanted to unblock staging deploy while I work on that.

<img width="799" alt="Screenshot 2025-06-23 at 12 29 11 PM" src="https://github.com/user-attachments/assets/335ea1f5-6eea-4369-985f-a99f08f46474" />
