### PR TITLE
Fyst 2131 write deploy to production GitHub action from pya 5

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -70,6 +70,23 @@ jobs:
           git tag ${{ steps.bump.outputs.new_tag }}
           git push origin ${{ steps.bump.outputs.new_tag }}
 
+      - name: Generate release notes
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          notes=$(gh release --repo ${{ github.repository }} \
+            view ${{ steps.bump.outputs.new_tag }} --json body -q ".body" || echo "")
+          if [ -z "$notes" ]; then
+            notes=$(gh release \
+              --repo ${{ github.repository }} \
+              view --generate-notes \
+              ${{ steps.bump.outputs.new_tag }} --json body -q ".body" || echo "No release notes found.")
+          fi
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
+          echo "$notes" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release with auto-generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,7 +104,7 @@ jobs:
         with:
           payload: |
             {
-              "text": ":rocket: A new release *${{ steps.bump.outputs.new_tag }}* is starting!\nTag: `${{ steps.bump.outputs.new_tag }}`\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump.outputs.new_tag }}|View on GitHub>\n:gear: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Action Logs>"
+              "text": ":rocket: A new release *${{ steps.bump.outputs.new_tag }}* is starting!\nTag: `${{ steps.bump.outputs.new_tag }}`\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump.outputs.new_tag }}|View on GitHub>\n:page_facing_up: *Release Notes:*\n${{ steps.release_notes.outputs.RELEASE_NOTES }}\n:gear: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Action Logs>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TAX_ENG_SLACK_URL }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -70,6 +70,17 @@ jobs:
           git tag ${{ steps.bump.outputs.new_tag }}
           git push origin ${{ steps.bump.outputs.new_tag }}
 
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="${{ github.event.inputs.release_title }}"
+          if [ -z "$TITLE" ]; then
+            TITLE="${{ steps.bump.outputs.new_tag }}"
+          fi
+          echo "Using release title: $TITLE"
+          gh release create ${{ steps.bump.outputs.new_tag }} --title "$TITLE" --generate-notes
+
       - name: Generate release notes
         id: release_notes
         env:
@@ -86,17 +97,6 @@ jobs:
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
           echo "$notes" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release with auto-generated notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TITLE="${{ github.event.inputs.release_title }}"
-          if [ -z "$TITLE" ]; then
-            TITLE="${{ steps.bump.outputs.new_tag }}"
-          fi
-          echo "Using release title: $TITLE"
-          gh release create ${{ steps.bump.outputs.new_tag }} --title "$TITLE" --generate-notes
 
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.24.0


### PR DESCRIPTION
https://github.com/codeforamerica/pya/actions/runs/16607798877/job/46984027655 

release notes not available, so creating the release first _and then_ fetching the notes for gh alert