### PR TITLE
Make sure to fetch tags

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           fetch-depth: 0  # fetch full history and tags
 
+      - name: Fetch tags explicitly
+        run: git fetch --tags
+
       - name: Get latest tag
         id: get_tag
         run: |


### PR DESCRIPTION
fetch tags explicitly. I'm seeing 12 instead of 15 
```
Run latest=$(git describe --tags --abbrev=0 || echo "v0.0.0")
##[debug]/usr/bin/bash -e /home/runner/work/_temp/464454e2-7d33-4f08-8af9-8adfe45dd76c.sh
Latest tag is v0.1.2
```

when I see 
<img width="309" height="233" alt="Screenshot 2025-07-29 at 3 29 38 PM" src="https://github.com/user-attachments/assets/7e054bf5-2b96-4000-812d-c4561bf17d60" />
