### PR TITLE
ignore shas that already exist

### DIFF
--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          if aws ecr describe-images --repository-name "${ECR_REPOSITORY}" --image-ids imageTag="${IMAGE_TAG}" >/dev/null 2>&1; then
+          if aws ecr describe-images --repository-name "${env.ECR_REPOSITORY}" --image-ids imageTag="${env.IMAGE_TAG}" >/dev/null 2>&1; then
             :
           else
             docker build -t 300423309117.dkr.ecr.us-east-1.amazonaws.com/pya-staging-web:${{env.IMAGE_TAG}} --platform linux/amd64 .


### PR DESCRIPTION
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

Right now after we deploy another branch to staging we are unable to redeploy main because we are trying to push the same immutable image tag (${{ github.sha }}) that already exists in ECR. Now we can by reusing the existing image and updating the SSM version parameter to trigger the infrastructure deployment.