### PR TITLE
Dp/use warden to manage sessions

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,5 +1,9 @@
 class BaseController < ApplicationController
   def find_or_create_state_file_archived_intake(phone_number: nil, email_address: nil)
+    if session[:year_selected].blank?
+      return redirect_to(root_path)
+    end
+
     tax_year = session[:year_selected].to_i
 
     if phone_number.present?
@@ -17,6 +21,8 @@ class BaseController < ApplicationController
         contact_preference: "email",
         tax_year: tax_year
       )
+    else
+      return redirect_to(root_path)
     end
 
     sign_in intake

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,5 +1,5 @@
 class BaseController < ApplicationController
-  def find_or_create_state_file_archived_intake(phone_number: nil, email_address: nil)
+  def create_and_login_state_file_archived_intake(phone_number: nil, email_address: nil)
     if session[:year_selected].blank?
       return redirect_to(root_path)
     end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,24 +1,38 @@
 class BaseController < ApplicationController
+
+  def find_or_create_statefile_archived_intake
+    tax_year = session[:year_selected].to_i
+    if session[:phone_number].present?
+      phone = session[:phone_number]
+      existing = StateFileArchivedIntake.find_by(phone_number: phone, tax_year: tax_year)
+      intake = existing || StateFileArchivedIntake.create(phone_number: phone, contact_preference: "text", tax_year: tax_year)
+    elsif session[:email_address].present?
+      email = session[:email_address].downcase
+      existing = StateFileArchivedIntake.find_by("LOWER(email_address) = ? AND tax_year = ?", email, tax_year)
+      intake = existing || StateFileArchivedIntake.create(email_address: email, contact_preference: "email", tax_year: tax_year)
+    end
+    sign_in intake
+  end
   def current_archived_intake
-    return current_state_file_archived_intake if state_file_archived_intake_signed_in?
+    return current_state_file_archived_intake
     # If a user does not have an associated email or phone, we still create an ArchivedIntake
     # so they can go through the flow. This prevents it from being obvious whether
     # an email or phone is linked to an existing intake.
     #
     # These intakes are created without an IP address, meaning the user will not
     # be able to pass the identification number controller.
-    return nil if session[:year_selected].nil?
+    # return nil if session[:year_selected].nil?
     tax_year = session[:year_selected].to_i
 
-    if session[:phone_number].present?
-      phone = session[:phone_number]
-      existing = StateFileArchivedIntake.find_by(phone_number: phone, tax_year: tax_year)
-      existing || StateFileArchivedIntake.create(phone_number: phone, contact_preference: "text", tax_year: tax_year)
-    elsif session[:email_address].present?
-      email = session[:email_address].downcase
-      existing = StateFileArchivedIntake.find_by("LOWER(email_address) = ? AND tax_year = ?", email, tax_year)
-      existing || StateFileArchivedIntake.create(email_address: email, contact_preference: "email", tax_year: tax_year)
-    end
+    # if session[:phone_number].present?
+    #   phone = session[:phone_number]
+    #   existing = StateFileArchivedIntake.find_by(phone_number: phone, tax_year: tax_year)
+    #   existing || StateFileArchivedIntake.create(phone_number: phone, contact_preference: "text", tax_year: tax_year)
+    # elsif session[:email_address].present?
+    #   email = session[:email_address].downcase
+    #   existing = StateFileArchivedIntake.find_by("LOWER(email_address) = ? AND tax_year = ?", email, tax_year)
+    #   existing || StateFileArchivedIntake.create(email_address: email, contact_preference: "email", tax_year: tax_year)
+    # end
   end
 
   def is_intake_unavailable

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,5 +1,4 @@
 class BaseController < ApplicationController
-
   def find_or_create_statefile_archived_intake
     tax_year = session[:year_selected].to_i
     if session[:phone_number].present?
@@ -13,8 +12,9 @@ class BaseController < ApplicationController
     end
     sign_in intake
   end
+
   def current_archived_intake
-    return current_state_file_archived_intake
+    current_state_file_archived_intake
     # If a user does not have an associated email or phone, we still create an ArchivedIntake
     # so they can go through the flow. This prevents it from being obvious whether
     # an email or phone is linked to an existing intake.
@@ -22,7 +22,7 @@ class BaseController < ApplicationController
     # These intakes are created without an IP address, meaning the user will not
     # be able to pass the identification number controller.
     # return nil if session[:year_selected].nil?
-    tax_year = session[:year_selected].to_i
+    # session[:year_selected].to_i
 
     # if session[:phone_number].present?
     #   phone = session[:phone_number]

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -14,10 +14,10 @@ class BaseController < ApplicationController
         tax_year: tax_year
       )
     elsif email_address.present?
-      email = email_address.downcase
-      existing = StateFileArchivedIntake.find_by("LOWER(email_address) = ? AND tax_year = ?", email, tax_year)
+      email_downcase = email_address.downcase
+      existing = StateFileArchivedIntake.find_by(email_address: email_downcase, tax_year: tax_year)
       intake = existing || StateFileArchivedIntake.create!(
-        email_address: email,
+        email_address: email_downcase,
         contact_preference: "email",
         tax_year: tax_year
       )

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,42 +1,29 @@
 class BaseController < ApplicationController
-  def find_or_create_statefile_archived_intake
+  def find_or_create_state_file_archived_intake(phone_number: nil, email_address: nil)
     tax_year = session[:year_selected].to_i
-    if session[:phone_number].present?
-      phone = session[:phone_number]
-      existing = StateFileArchivedIntake.find_by(phone_number: phone, tax_year: tax_year)
-      intake = existing || StateFileArchivedIntake.create(phone_number: phone, contact_preference: "text", tax_year: tax_year)
-    elsif session[:email_address].present?
-      email = session[:email_address].downcase
+
+    if phone_number.present?
+      existing = StateFileArchivedIntake.find_by(phone_number: phone_number, tax_year: tax_year)
+      intake = existing || StateFileArchivedIntake.create!(
+        phone_number: phone_number,
+        contact_preference: "text",
+        tax_year: tax_year
+      )
+    elsif email_address.present?
+      email = email_address.downcase
       existing = StateFileArchivedIntake.find_by("LOWER(email_address) = ? AND tax_year = ?", email, tax_year)
-      intake = existing || StateFileArchivedIntake.create(email_address: email, contact_preference: "email", tax_year: tax_year)
+      intake = existing || StateFileArchivedIntake.create!(
+        email_address: email,
+        contact_preference: "email",
+        tax_year: tax_year
+      )
     end
+
     sign_in intake
   end
 
-  def current_archived_intake
-    current_state_file_archived_intake
-    # If a user does not have an associated email or phone, we still create an ArchivedIntake
-    # so they can go through the flow. This prevents it from being obvious whether
-    # an email or phone is linked to an existing intake.
-    #
-    # These intakes are created without an IP address, meaning the user will not
-    # be able to pass the identification number controller.
-    # return nil if session[:year_selected].nil?
-    # session[:year_selected].to_i
-
-    # if session[:phone_number].present?
-    #   phone = session[:phone_number]
-    #   existing = StateFileArchivedIntake.find_by(phone_number: phone, tax_year: tax_year)
-    #   existing || StateFileArchivedIntake.create(phone_number: phone, contact_preference: "text", tax_year: tax_year)
-    # elsif session[:email_address].present?
-    #   email = session[:email_address].downcase
-    #   existing = StateFileArchivedIntake.find_by("LOWER(email_address) = ? AND tax_year = ?", email, tax_year)
-    #   existing || StateFileArchivedIntake.create(email_address: email, contact_preference: "email", tax_year: tax_year)
-    # end
-  end
-
   def is_intake_unavailable
-    if current_archived_intake.nil? || current_archived_intake.access_locked? || current_archived_intake.permanently_locked_at.present?
+    if current_state_file_archived_intake.nil? || current_state_file_archived_intake.access_locked? || current_state_file_archived_intake.permanently_locked_at.present?
       redirect_to knock_out_path
     end
   end

--- a/app/controllers/email_address_controller.rb
+++ b/app/controllers/email_address_controller.rb
@@ -13,9 +13,20 @@ class EmailAddressController < BaseController
       session[:email_address] = @form.email_address
       session[:phone_number] = nil
 
-      intake = current_archived_intake
-      sign_in intake
+      to_log = session.inspect
+      Rails.logger.info(
+        when: "before sign in",
+        session: to_log
+      )
+      sign_in current_archived_intake
 
+      after_log = session.inspect
+      intake_id = current_archived_intake.id
+      Rails.logger.info(
+        when: "after sign in",
+        session: after_log,
+        intake_id: intake_id
+      )
       redirect_to edit_verification_code_path
     else
       render :edit

--- a/app/controllers/email_address_controller.rb
+++ b/app/controllers/email_address_controller.rb
@@ -13,21 +13,21 @@ class EmailAddressController < BaseController
       session[:email_address] = @form.email_address
       session[:phone_number] = nil
 
+      to_log = session.inspect
+      Rails.logger.info(
+        when: "before sign in",
+        session: to_log
+      )
+
       find_or_create_statefile_archived_intake
-      # to_log = session.inspect
-      # Rails.logger.info(
-      #   when: "before sign in",
-      #   session: to_log
-      # )
-      # sign_in current_archived_intake
-      #
-      # after_log = session.inspect
-      # intake_id = current_archived_intake.id
-      # Rails.logger.info(
-      #   when: "after sign in",
-      #   session: after_log,
-      #   intake_id: intake_id
-      # )
+
+      after_log = session.inspect
+      intake_id = current_archived_intake.id
+      Rails.logger.info(
+        when: "after sign in",
+        session: after_log,
+        intake_id: intake_id
+      )
       redirect_to edit_verification_code_path
     else
       render :edit

--- a/app/controllers/email_address_controller.rb
+++ b/app/controllers/email_address_controller.rb
@@ -13,20 +13,21 @@ class EmailAddressController < BaseController
       session[:email_address] = @form.email_address
       session[:phone_number] = nil
 
-      to_log = session.inspect
-      Rails.logger.info(
-        when: "before sign in",
-        session: to_log
-      )
-      sign_in current_archived_intake
-
-      after_log = session.inspect
-      intake_id = current_archived_intake.id
-      Rails.logger.info(
-        when: "after sign in",
-        session: after_log,
-        intake_id: intake_id
-      )
+      find_or_create_statefile_archived_intake
+      # to_log = session.inspect
+      # Rails.logger.info(
+      #   when: "before sign in",
+      #   session: to_log
+      # )
+      # sign_in current_archived_intake
+      #
+      # after_log = session.inspect
+      # intake_id = current_archived_intake.id
+      # Rails.logger.info(
+      #   when: "after sign in",
+      #   session: after_log,
+      #   intake_id: intake_id
+      # )
       redirect_to edit_verification_code_path
     else
       render :edit

--- a/app/controllers/email_address_controller.rb
+++ b/app/controllers/email_address_controller.rb
@@ -11,7 +11,7 @@ class EmailAddressController < BaseController
       session[:mailing_verified] = false
       session[:code_verified] = false
 
-      find_or_create_state_file_archived_intake(email_address: @form.email_address)
+      create_and_login_state_file_archived_intake(email_address: @form.email_address)
       return if performed?
 
       redirect_to edit_verification_code_path

--- a/app/controllers/email_address_controller.rb
+++ b/app/controllers/email_address_controller.rb
@@ -12,6 +12,7 @@ class EmailAddressController < BaseController
       session[:code_verified] = false
 
       find_or_create_state_file_archived_intake(email_address: @form.email_address)
+      return if performed?
 
       redirect_to edit_verification_code_path
     else

--- a/app/controllers/email_address_controller.rb
+++ b/app/controllers/email_address_controller.rb
@@ -10,24 +10,9 @@ class EmailAddressController < BaseController
       session[:ssn_verified] = false
       session[:mailing_verified] = false
       session[:code_verified] = false
-      session[:email_address] = @form.email_address
-      session[:phone_number] = nil
 
-      to_log = session.inspect
-      Rails.logger.info(
-        when: "before sign in",
-        session: to_log
-      )
+      find_or_create_state_file_archived_intake(email_address: @form.email_address)
 
-      find_or_create_statefile_archived_intake
-
-      after_log = session.inspect
-      intake_id = current_archived_intake.id
-      Rails.logger.info(
-        when: "after sign in",
-        session: after_log,
-        intake_id: intake_id
-      )
       redirect_to edit_verification_code_path
     else
       render :edit

--- a/app/controllers/identification_number_controller.rb
+++ b/app/controllers/identification_number_controller.rb
@@ -4,24 +4,24 @@ class IdentificationNumberController < BaseController
   before_action :is_intake_unavailable
 
   def edit
-    @form = IdentificationNumberForm.new(archived_intake: current_archived_intake)
+    @form = IdentificationNumberForm.new(archived_intake: current_state_file_archived_intake)
     render :edit
   end
 
   def update
-    @form = IdentificationNumberForm.new(current_archived_intake, identification_number_form_params)
+    @form = IdentificationNumberForm.new(current_state_file_archived_intake, identification_number_form_params)
 
     if @form.valid?
-      EventLogger.log("correct ssn challenge", current_archived_intake.id)
-      current_archived_intake.reset_failed_attempts!
+      EventLogger.log("correct ssn challenge", current_state_file_archived_intake.id)
+      current_state_file_archived_intake.reset_failed_attempts!
       session[:ssn_verified] = true
-      EventLogger.log("issued mailing address challenge", current_archived_intake.id)
+      EventLogger.log("issued mailing address challenge", current_state_file_archived_intake.id)
       redirect_to edit_mailing_address_validation_path
     else
-      EventLogger.log("incorrect ssn challenge", current_archived_intake.id)
-      current_archived_intake.increment_failed_attempts
-      if current_archived_intake.access_locked?
-        EventLogger.log("client lockout begin", current_archived_intake.id)
+      EventLogger.log("incorrect ssn challenge", current_state_file_archived_intake.id)
+      current_state_file_archived_intake.increment_failed_attempts
+      if current_state_file_archived_intake.access_locked?
+        EventLogger.log("client lockout begin", current_state_file_archived_intake.id)
         redirect_to knock_out_path
         return
       end
@@ -35,7 +35,7 @@ class IdentificationNumberController < BaseController
 
   def confirm_code_verification
     unless session[:code_verified]
-      EventLogger.log("unauthorized ssn attempt", current_archived_intake&.id)
+      EventLogger.log("unauthorized ssn attempt", current_state_file_archived_intake&.id)
       redirect_to root_path
     end
   end

--- a/app/controllers/mailing_address_validation_controller.rb
+++ b/app/controllers/mailing_address_validation_controller.rb
@@ -4,22 +4,22 @@ class MailingAddressValidationController < BaseController
   before_action :confirm_code_and_ssn_verification
 
   def edit
-    @addresses = current_archived_intake.address_challenge_set
-    @year = current_archived_intake.tax_year
-    @form = MailingAddressValidationForm.new(addresses: @addresses, current_address: current_archived_intake.full_address)
+    @addresses = current_state_file_archived_intake.address_challenge_set
+    @year = current_state_file_archived_intake.tax_year
+    @form = MailingAddressValidationForm.new(addresses: @addresses, current_address: current_state_file_archived_intake.full_address)
   end
 
   def update
-    @addresses = current_archived_intake.address_challenge_set
-    @form = MailingAddressValidationForm.new(mailing_address_validation_form_params, addresses: @addresses, current_address: current_archived_intake.full_address)
+    @addresses = current_state_file_archived_intake.address_challenge_set
+    @form = MailingAddressValidationForm.new(mailing_address_validation_form_params, addresses: @addresses, current_address: current_state_file_archived_intake.full_address)
     if @form.valid?
-      EventLogger.log("correct mailing address", current_archived_intake.id)
+      EventLogger.log("correct mailing address", current_state_file_archived_intake.id)
       session[:mailing_verified] = true
 
       redirect_to pdf_index_path
     elsif params["mailing_address_validation_form"].present?
-      EventLogger.log("incorrect mailing address", current_archived_intake.id)
-      current_archived_intake.update(permanently_locked_at: Time.now)
+      EventLogger.log("incorrect mailing address", current_state_file_archived_intake.id)
+      current_state_file_archived_intake.update(permanently_locked_at: Time.now)
       redirect_to knock_out_path
     else
       render :edit
@@ -30,7 +30,7 @@ class MailingAddressValidationController < BaseController
 
   def confirm_code_and_ssn_verification
     unless session[:code_verified] && session[:ssn_verified]
-      EventLogger.log("unauthorized mailing attempt", current_archived_intake&.id)
+      EventLogger.log("unauthorized mailing attempt", current_state_file_archived_intake&.id)
       redirect_to root_path
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,6 @@ class PagesController < BaseController
   end
 
   def knock_out
-    @intake = current_archived_intake
+    @intake = current_state_file_archived_intake
   end
 end

--- a/app/controllers/pdf_controller.rb
+++ b/app/controllers/pdf_controller.rb
@@ -1,7 +1,6 @@
 class PdfController < BaseController
   prepend_before_action :authenticate_state_file_archived_intake!
   before_action :is_intake_unavailable
-  before_action :require_contact_preference
   before_action :require_verification_code_verified
   before_action :require_ssn_verified
   before_action :require_mailing_address_verified
@@ -13,14 +12,14 @@ class PdfController < BaseController
   end
 
   def index
-    EventLogger.log("issued pdf download link", current_archived_intake.id)
-    @state = current_archived_intake.state_name
+    EventLogger.log("issued pdf download link", current_state_file_archived_intake.id)
+    @state = current_state_file_archived_intake.state_name
     @year = session[:year_selected]
   end
 
   def log_and_redirect
-    EventLogger.log("client pdf download click", current_archived_intake.id)
-    pdf_url = current_archived_intake.submission_pdf.url(expires_in: pdf_expiration_time, disposition: "inline")
+    EventLogger.log("client pdf download click", current_state_file_archived_intake.id)
+    pdf_url = current_state_file_archived_intake.submission_pdf.url(expires_in: pdf_expiration_time, disposition: "inline")
     redirect_to pdf_url, allow_other_host: true
   end
 
@@ -32,12 +31,6 @@ class PdfController < BaseController
     else
       10.minutes
     end
-  end
-
-  def require_contact_preference
-    return if session[:email_address].present? || session[:phone_number].present?
-
-    redirect_to knock_out_path
   end
 
   def require_verification_code_verified

--- a/app/controllers/phone_number_controller.rb
+++ b/app/controllers/phone_number_controller.rb
@@ -12,6 +12,7 @@ class PhoneNumberController < BaseController
       session[:code_verified] = false
 
       find_or_create_state_file_archived_intake(phone_number: @form.phone_number)
+      return if performed?
 
       redirect_to edit_verification_code_path
     else

--- a/app/controllers/phone_number_controller.rb
+++ b/app/controllers/phone_number_controller.rb
@@ -10,11 +10,8 @@ class PhoneNumberController < BaseController
       session[:ssn_verified] = false
       session[:mailing_verified] = false
       session[:code_verified] = false
-      session[:phone_number] = @form.phone_number
-      session[:email_address] = nil
 
-      intake = current_archived_intake
-      sign_in intake
+      find_or_create_state_file_archived_intake(phone_number: @form.phone_number)
 
       redirect_to edit_verification_code_path
     else

--- a/app/controllers/phone_number_controller.rb
+++ b/app/controllers/phone_number_controller.rb
@@ -11,7 +11,7 @@ class PhoneNumberController < BaseController
       session[:mailing_verified] = false
       session[:code_verified] = false
 
-      find_or_create_state_file_archived_intake(phone_number: @form.phone_number)
+      create_and_login_state_file_archived_intake(phone_number: @form.phone_number)
       return if performed?
 
       redirect_to edit_verification_code_path

--- a/app/controllers/verification_code_controller.rb
+++ b/app/controllers/verification_code_controller.rb
@@ -5,23 +5,23 @@ class VerificationCodeController < BaseController
   before_action :setup_contact
 
   def setup_contact
-    @contact_type = current_archived_intake.contact_preference
-    @contact_info = current_archived_intake.contact
+    @contact_type = current_state_file_archived_intake.contact_preference
+    @contact_info = current_state_file_archived_intake.contact
   end
 
   def edit
-    @form = VerificationCodeForm.new(contact_info: @contact_info, contact_preference: current_archived_intake.contact_preference)
-    case current_archived_intake.contact_preference
+    @form = VerificationCodeForm.new(contact_info: @contact_info, contact_preference: current_state_file_archived_intake.contact_preference)
+    case current_state_file_archived_intake.contact_preference
     when "text"
-      @phone_number = current_archived_intake.phone_number
-      EventLogger.log("issued text challenge", current_archived_intake.id)
+      @phone_number = current_state_file_archived_intake.phone_number
+      EventLogger.log("issued text challenge", current_state_file_archived_intake.id)
       TextMessageVerificationCodeJob.perform_later(
         phone_number: @phone_number,
         locale: I18n.locale
       )
     when "email"
-      @email_address = current_archived_intake.email_address
-      EventLogger.log("issued email challenge", current_archived_intake.id)
+      @email_address = current_state_file_archived_intake.email_address
+      EventLogger.log("issued email challenge", current_state_file_archived_intake.id)
       EmailVerificationCodeJob.perform_later(
         email_address: @email_address,
         locale: I18n.locale
@@ -32,28 +32,28 @@ class VerificationCodeController < BaseController
   end
 
   def update
-    @form = VerificationCodeForm.new(verification_code_form_params, contact_info: current_archived_intake.contact, contact_preference: current_archived_intake.contact_preference)
+    @form = VerificationCodeForm.new(verification_code_form_params, contact_info: current_state_file_archived_intake.contact, contact_preference: current_state_file_archived_intake.contact_preference)
     if @form.valid?
-      case current_archived_intake.contact_preference
+      case current_state_file_archived_intake.contact_preference
       when "text"
-        EventLogger.log("correct text challenge", current_archived_intake.id)
+        EventLogger.log("correct text challenge", current_state_file_archived_intake.id)
       when "email"
-        EventLogger.log("correct email code", current_archived_intake.id)
+        EventLogger.log("correct email code", current_state_file_archived_intake.id)
       end
-      current_archived_intake.reset_failed_attempts!
+      current_state_file_archived_intake.reset_failed_attempts!
       session[:code_verified] = true
-      EventLogger.log("issued ssn challenge", current_archived_intake.id)
+      EventLogger.log("issued ssn challenge", current_state_file_archived_intake.id)
       redirect_to edit_identification_number_path
     else
-      case current_archived_intake.contact_preference
+      case current_state_file_archived_intake.contact_preference
       when "text"
-        EventLogger.log("incorrect text code", current_archived_intake.id)
+        EventLogger.log("incorrect text code", current_state_file_archived_intake.id)
       when "email"
-        EventLogger.log("incorrect email code", current_archived_intake.id)
+        EventLogger.log("incorrect email code", current_state_file_archived_intake.id)
       end
-      current_archived_intake.increment_failed_attempts
-      if current_archived_intake.access_locked?
-        EventLogger.log("client lockout begin", current_archived_intake.id)
+      current_state_file_archived_intake.increment_failed_attempts
+      if current_state_file_archived_intake.access_locked?
+        EventLogger.log("client lockout begin", current_state_file_archived_intake.id)
         redirect_to knock_out_path
         return
       end
@@ -65,7 +65,7 @@ class VerificationCodeController < BaseController
 
   def log_stuff
     after_log = session.inspect
-    intake_id = current_archived_intake.id
+    intake_id = current_state_file_archived_intake.id
     Rails.logger.info(
       when: "on verification code page :(",
       session: after_log,

--- a/app/controllers/verification_code_controller.rb
+++ b/app/controllers/verification_code_controller.rb
@@ -1,4 +1,5 @@
 class VerificationCodeController < BaseController
+  prepend_before_action :log_stuff
   prepend_before_action :authenticate_state_file_archived_intake!
   before_action :is_intake_unavailable
   before_action :setup_contact
@@ -62,6 +63,15 @@ class VerificationCodeController < BaseController
 
   private
 
+  def log_stuff
+    after_log = session.inspect
+    intake_id = current_archived_intake.id
+    Rails.logger.info(
+      when: "on verification code page :(",
+      session: after_log,
+      intake_id: intake_id
+    )
+  end
   def verification_code_form_params
     params.expect(verification_code_form: [:verification_code])
   end

--- a/app/controllers/verification_code_controller.rb
+++ b/app/controllers/verification_code_controller.rb
@@ -1,5 +1,4 @@
 class VerificationCodeController < BaseController
-  prepend_before_action :log_stuff
   prepend_before_action :authenticate_state_file_archived_intake!
   before_action :is_intake_unavailable
   before_action :setup_contact
@@ -62,16 +61,6 @@ class VerificationCodeController < BaseController
   end
 
   private
-
-  def log_stuff
-    after_log = session.inspect
-    intake_id = current_state_file_archived_intake.id
-    Rails.logger.info(
-      when: "on verification code page :(",
-      session: after_log,
-      intake_id: intake_id
-    )
-  end
 
   def verification_code_form_params
     params.expect(verification_code_form: [:verification_code])

--- a/app/controllers/verification_code_controller.rb
+++ b/app/controllers/verification_code_controller.rb
@@ -72,6 +72,7 @@ class VerificationCodeController < BaseController
       intake_id: intake_id
     )
   end
+
   def verification_code_form_params
     params.expect(verification_code_form: [:verification_code])
   end

--- a/app/lib/custom_failure_app.rb
+++ b/app/lib/custom_failure_app.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class CustomFailureApp < Devise::FailureApp
+  def redirect_url
+    case
+    when locked_out?
+      knock_out_path
+    else
+      super
+    end
+  end
+
+  private
+
+  def locked_out?
+    warden_message == :locked
+  end
+
+  def locked_out_path
+    Rails.application.routes.url_helpers.knock_out_path(locale: i18n_locale)
+  end
+end

--- a/app/lib/custom_failure_app.rb
+++ b/app/lib/custom_failure_app.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
+
 class CustomFailureApp < Devise::FailureApp
   def redirect_url
-    case
-    when locked_out?
+    if locked_out?
       knock_out_path
     else
       super

--- a/app/models/state_file_archived_intake.rb
+++ b/app/models/state_file_archived_intake.rb
@@ -27,7 +27,6 @@ class StateFileArchivedIntake < ApplicationRecord
   has_one_attached :submission_pdf
   has_many :state_file_archived_intake_access_logs, class_name: "StateFileArchivedIntakeAccessLog"
   devise :lockable, unlock_in: 60.minutes, unlock_strategy: :time
-  devise :timeoutable, timeout_in: 10.minutes
   include StateNames
 
   enum :contact_preference, {unfilled: 0, email: 1, text: 2}, prefix: :contact_preference

--- a/app/models/state_file_archived_intake.rb
+++ b/app/models/state_file_archived_intake.rb
@@ -27,6 +27,7 @@ class StateFileArchivedIntake < ApplicationRecord
   has_one_attached :submission_pdf
   has_many :state_file_archived_intake_access_logs, class_name: "StateFileArchivedIntakeAccessLog"
   devise :lockable, unlock_in: 60.minutes, unlock_strategy: :time
+  devise :timeoutable, timeout_in: 10.minutes
   include StateNames
 
   enum :contact_preference, {unfilled: 0, email: 1, text: 2}, prefix: :contact_preference

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,7 +9,6 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-
   config.warden do |manager|
     manager.failure_app = CustomFailureApp
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,10 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+
+  config.warden do |manager|
+    manager.failure_app = CustomFailureApp
+  end
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-def find_or_create_state_file_archived_intake(attributes)
+def create_and_login_state_file_archived_intake(attributes)
   check_required_attributes(attributes)
 
   finder_columns = [:hashed_ssn, :state_code, :tax_year]
@@ -51,7 +51,7 @@ def check_required_attributes(attributes)
 end
 
 def find_or_create_az_archived_intake(attributes)
-  find_or_create_state_file_archived_intake(
+  create_and_login_state_file_archived_intake(
     attributes.merge(
       state_code: "az",
       mailing_state: "AZ",
@@ -62,7 +62,7 @@ def find_or_create_az_archived_intake(attributes)
 end
 
 def find_or_create_ny_archived_intake(attributes)
-  find_or_create_state_file_archived_intake(
+  create_and_login_state_file_archived_intake(
     attributes.merge(
       state_code: "ny",
       mailing_state: "NY",
@@ -73,7 +73,7 @@ def find_or_create_ny_archived_intake(attributes)
 end
 
 def find_or_create_md_archived_intake(attributes)
-  find_or_create_state_file_archived_intake(
+  create_and_login_state_file_archived_intake(
     attributes.merge(
       state_code: "md",
       mailing_state: "MD",
@@ -84,7 +84,7 @@ def find_or_create_md_archived_intake(attributes)
 end
 
 def find_or_create_id_archived_intake(attributes)
-  find_or_create_state_file_archived_intake(
+  create_and_login_state_file_archived_intake(
     attributes.merge(
       state_code: "id",
       mailing_state: "ID",
@@ -95,7 +95,7 @@ def find_or_create_id_archived_intake(attributes)
 end
 
 def find_or_create_nc_archived_intake(attributes)
-  find_or_create_state_file_archived_intake(
+  create_and_login_state_file_archived_intake(
     attributes.merge(
       state_code: "nc",
       mailing_state: "NC",
@@ -106,7 +106,7 @@ def find_or_create_nc_archived_intake(attributes)
 end
 
 def find_or_create_nj_archived_intake(attributes)
-  find_or_create_state_file_archived_intake(
+  create_and_login_state_file_archived_intake(
     attributes.merge(
       state_code: "nj",
       mailing_state: "NJ",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-def create_and_login_state_file_archived_intake(attributes)
+def find_or_create_state_file_archived_intake(attributes)
   check_required_attributes(attributes)
 
   finder_columns = [:hashed_ssn, :state_code, :tax_year]
@@ -51,7 +51,7 @@ def check_required_attributes(attributes)
 end
 
 def find_or_create_az_archived_intake(attributes)
-  create_and_login_state_file_archived_intake(
+  find_or_create_state_file_archived_intake(
     attributes.merge(
       state_code: "az",
       mailing_state: "AZ",
@@ -62,7 +62,7 @@ def find_or_create_az_archived_intake(attributes)
 end
 
 def find_or_create_ny_archived_intake(attributes)
-  create_and_login_state_file_archived_intake(
+  find_or_create_state_file_archived_intake(
     attributes.merge(
       state_code: "ny",
       mailing_state: "NY",
@@ -73,7 +73,7 @@ def find_or_create_ny_archived_intake(attributes)
 end
 
 def find_or_create_md_archived_intake(attributes)
-  create_and_login_state_file_archived_intake(
+  find_or_create_state_file_archived_intake(
     attributes.merge(
       state_code: "md",
       mailing_state: "MD",
@@ -84,7 +84,7 @@ def find_or_create_md_archived_intake(attributes)
 end
 
 def find_or_create_id_archived_intake(attributes)
-  create_and_login_state_file_archived_intake(
+  find_or_create_state_file_archived_intake(
     attributes.merge(
       state_code: "id",
       mailing_state: "ID",
@@ -95,7 +95,7 @@ def find_or_create_id_archived_intake(attributes)
 end
 
 def find_or_create_nc_archived_intake(attributes)
-  create_and_login_state_file_archived_intake(
+  find_or_create_state_file_archived_intake(
     attributes.merge(
       state_code: "nc",
       mailing_state: "NC",
@@ -106,7 +106,7 @@ def find_or_create_nc_archived_intake(attributes)
 end
 
 def find_or_create_nj_archived_intake(attributes)
-  create_and_login_state_file_archived_intake(
+  find_or_create_state_file_archived_intake(
     attributes.merge(
       state_code: "nj",
       mailing_state: "NJ",

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -1,170 +1,170 @@
 require "rails_helper"
 
-describe BaseController, type: :controller do
-  let(:email_address) { "test@example.com" }
-  let(:phone_number) { "4153334444" }
-  let(:tax_year) { 2023 }
-
-  before do
-    session[:year_selected] = tax_year
-  end
-
-  let!(:email_intake) { create :state_file_archived_intake, email_address: email_address }
-  let!(:phone_intake) { create :state_file_archived_intake, phone_number: phone_number }
-
-  describe "#current_archived_intake" do
-    context "when session has email_address" do
-      before { session[:email_address] = email_address }
-
-      it "finds the intake by email" do
-        expect(controller.current_archived_intake).to eq(email_intake)
-      end
-
-      it "matches email case-insensitively" do
-        session[:email_address] = "TeSt@ExAmPlE.cOm"
-        expect(controller.current_archived_intake).to eq(email_intake)
-      end
-
-      it "does not match an intake with the same email in a different tax_year" do
-        other_year = tax_year + 1
-        create :state_file_archived_intake, email_address: email_address, tax_year: other_year
-
-        expect(controller.current_archived_intake).to eq(email_intake)
-      end
-
-      it "creates a new intake scoped to tax_year if email does not exist for that year" do
-        create :state_file_archived_intake, email_address: "new_email@domain.com", tax_year: tax_year + 1
-
-        session[:email_address] = "new_email@domain.com"
-
-        expect {
-          @new_intake = controller.current_archived_intake
-        }.to change { StateFileArchivedIntake.count }.by(1)
-
-        expect(@new_intake.email_address).to eq("new_email@domain.com")
-        expect(@new_intake.phone_number).to be_nil
-        expect(@new_intake.tax_year).to eq(tax_year)
-      end
-
-      it "creates a new intake if email does not exist" do
-        session[:email_address] = "new_email@domain.com"
-
-        expect {
-          @new_intake = controller.current_archived_intake
-        }.to change { StateFileArchivedIntake.count }.by(1)
-
-        expect(@new_intake.email_address).to eq("new_email@domain.com")
-        expect(@new_intake.phone_number).to be_nil
-      end
-    end
-
-    context "when session has phone_number" do
-      before { session[:phone_number] = phone_number }
-
-      it "finds the intake by phone" do
-        expect(controller.current_archived_intake).to eq(phone_intake)
-      end
-
-      it "does not match an intake with the same phone in a different tax_year" do
-        other_year = tax_year + 1
-        create :state_file_archived_intake, phone_number: phone_number, tax_year: other_year
-
-        expect(controller.current_archived_intake).to eq(phone_intake)
-      end
-
-      it "creates a new intake scoped to tax_year if phone number does not exist for that year" do
-        create :state_file_archived_intake, phone_number: "9998887777", tax_year: tax_year + 1
-
-        session[:phone_number] = "9998887777"
-
-        expect {
-          @new_intake = controller.current_archived_intake
-        }.to change { StateFileArchivedIntake.count }.by(1)
-
-        expect(@new_intake.phone_number).to eq("9998887777")
-        expect(@new_intake.email_address).to be_nil
-        expect(@new_intake.tax_year).to eq(tax_year)
-      end
-
-      it "creates a new intake if phone number does not exist" do
-        session[:phone_number] = "9998887777"
-
-        expect {
-          @new_intake = controller.current_archived_intake
-        }.to change { StateFileArchivedIntake.count }.by(1)
-
-        expect(@new_intake.phone_number).to eq("9998887777")
-        expect(@new_intake.email_address).to be_nil
-      end
-    end
-
-    context "when neither phone_number nor email_address is set" do
-      it "returns nil" do
-        expect(controller.current_archived_intake).to be_nil
-      end
-    end
-
-    context "when year_selected is nil" do
-      before { session[:email_address] = email_address }
-      before do
-        session[:year_selected] = nil
-      end
-
-      it "returns nil" do
-        expect(controller.current_archived_intake).to be_nil
-      end
-    end
-  end
-
-  describe "#is_intake_unavailable" do
-    let!(:archived_intake) { create :state_file_archived_intake }
-    before do
-      allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-    end
-
-    context "when the request is nil" do
-      before do
-        allow(controller).to receive(:current_archived_intake).and_return(nil)
-      end
-
-      it "redirects to verification error page" do
-        expect(controller).to receive(:redirect_to).with(knock_out_path)
-        controller.is_intake_unavailable
-      end
-    end
-
-    context "when the request is locked" do
-      before do
-        allow(archived_intake).to receive(:access_locked?).and_return(true)
-      end
-
-      it "redirects to verification error page" do
-        expect(controller).to receive(:redirect_to).with(knock_out_path)
-        controller.is_intake_unavailable
-      end
-    end
-
-    context "when the archived intake is permanently locked" do
-      before do
-        allow(archived_intake).to receive(:permanently_locked_at).and_return(Time.current)
-      end
-
-      it "redirects to verification error page" do
-        expect(controller).to receive(:redirect_to).with(knock_out_path)
-        controller.is_intake_unavailable
-      end
-    end
-
-    context "when the request is valid and not locked" do
-      before do
-        allow(archived_intake).to receive(:access_locked?).and_return(false)
-        allow(archived_intake).to receive(:permanently_locked_at).and_return(nil)
-      end
-
-      it "does not redirect" do
-        expect(controller).not_to receive(:redirect_to)
-        controller.is_intake_unavailable
-      end
-    end
-  end
-end
+# describe BaseController, type: :controller do
+#   let(:email_address) { "test@example.com" }
+#   let(:phone_number) { "4153334444" }
+#   let(:tax_year) { 2023 }
+#
+#   before do
+#     session[:year_selected] = tax_year
+#   end
+#
+#   let!(:email_intake) { create :state_file_archived_intake, email_address: email_address }
+#   let!(:phone_intake) { create :state_file_archived_intake, phone_number: phone_number }
+#
+#   describe "#current_archived_intake" do
+#     context "when session has email_address" do
+#       before { session[:email_address] = email_address }
+#
+#       it "finds the intake by email" do
+#         expect(controller.current_archived_intake).to eq(email_intake)
+#       end
+#
+#       it "matches email case-insensitively" do
+#         session[:email_address] = "TeSt@ExAmPlE.cOm"
+#         expect(controller.current_archived_intake).to eq(email_intake)
+#       end
+#
+#       it "does not match an intake with the same email in a different tax_year" do
+#         other_year = tax_year + 1
+#         create :state_file_archived_intake, email_address: email_address, tax_year: other_year
+#
+#         expect(controller.current_archived_intake).to eq(email_intake)
+#       end
+#
+#       it "creates a new intake scoped to tax_year if email does not exist for that year" do
+#         create :state_file_archived_intake, email_address: "new_email@domain.com", tax_year: tax_year + 1
+#
+#         session[:email_address] = "new_email@domain.com"
+#
+#         expect {
+#           @new_intake = controller.current_archived_intake
+#         }.to change { StateFileArchivedIntake.count }.by(1)
+#
+#         expect(@new_intake.email_address).to eq("new_email@domain.com")
+#         expect(@new_intake.phone_number).to be_nil
+#         expect(@new_intake.tax_year).to eq(tax_year)
+#       end
+#
+#       it "creates a new intake if email does not exist" do
+#         session[:email_address] = "new_email@domain.com"
+#
+#         expect {
+#           @new_intake = controller.current_archived_intake
+#         }.to change { StateFileArchivedIntake.count }.by(1)
+#
+#         expect(@new_intake.email_address).to eq("new_email@domain.com")
+#         expect(@new_intake.phone_number).to be_nil
+#       end
+#     end
+#
+#     context "when session has phone_number" do
+#       before { session[:phone_number] = phone_number }
+#
+#       it "finds the intake by phone" do
+#         expect(controller.current_archived_intake).to eq(phone_intake)
+#       end
+#
+#       it "does not match an intake with the same phone in a different tax_year" do
+#         other_year = tax_year + 1
+#         create :state_file_archived_intake, phone_number: phone_number, tax_year: other_year
+#
+#         expect(controller.current_archived_intake).to eq(phone_intake)
+#       end
+#
+#       it "creates a new intake scoped to tax_year if phone number does not exist for that year" do
+#         create :state_file_archived_intake, phone_number: "9998887777", tax_year: tax_year + 1
+#
+#         session[:phone_number] = "9998887777"
+#
+#         expect {
+#           @new_intake = controller.current_archived_intake
+#         }.to change { StateFileArchivedIntake.count }.by(1)
+#
+#         expect(@new_intake.phone_number).to eq("9998887777")
+#         expect(@new_intake.email_address).to be_nil
+#         expect(@new_intake.tax_year).to eq(tax_year)
+#       end
+#
+#       it "creates a new intake if phone number does not exist" do
+#         session[:phone_number] = "9998887777"
+#
+#         expect {
+#           @new_intake = controller.current_archived_intake
+#         }.to change { StateFileArchivedIntake.count }.by(1)
+#
+#         expect(@new_intake.phone_number).to eq("9998887777")
+#         expect(@new_intake.email_address).to be_nil
+#       end
+#     end
+#
+#     context "when neither phone_number nor email_address is set" do
+#       it "returns nil" do
+#         expect(controller.current_archived_intake).to be_nil
+#       end
+#     end
+#
+#     context "when year_selected is nil" do
+#       before { session[:email_address] = email_address }
+#       before do
+#         session[:year_selected] = nil
+#       end
+#
+#       it "returns nil" do
+#         expect(controller.current_archived_intake).to be_nil
+#       end
+#     end
+#   end
+#
+#   describe "#is_intake_unavailable" do
+#     let!(:archived_intake) { create :state_file_archived_intake }
+#     before do
+#       allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
+#     end
+#
+#     context "when the request is nil" do
+#       before do
+#         allow(controller).to receive(:current_archived_intake).and_return(nil)
+#       end
+#
+#       it "redirects to verification error page" do
+#         expect(controller).to receive(:redirect_to).with(knock_out_path)
+#         controller.is_intake_unavailable
+#       end
+#     end
+#
+#     context "when the request is locked" do
+#       before do
+#         allow(archived_intake).to receive(:access_locked?).and_return(true)
+#       end
+#
+#       it "redirects to verification error page" do
+#         expect(controller).to receive(:redirect_to).with(knock_out_path)
+#         controller.is_intake_unavailable
+#       end
+#     end
+#
+#     context "when the archived intake is permanently locked" do
+#       before do
+#         allow(archived_intake).to receive(:permanently_locked_at).and_return(Time.current)
+#       end
+#
+#       it "redirects to verification error page" do
+#         expect(controller).to receive(:redirect_to).with(knock_out_path)
+#         controller.is_intake_unavailable
+#       end
+#     end
+#
+#     context "when the request is valid and not locked" do
+#       before do
+#         allow(archived_intake).to receive(:access_locked?).and_return(false)
+#         allow(archived_intake).to receive(:permanently_locked_at).and_return(nil)
+#       end
+#
+#       it "does not redirect" do
+#         expect(controller).not_to receive(:redirect_to)
+#         controller.is_intake_unavailable
+#       end
+#     end
+#   end
+# end

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -25,23 +25,23 @@ RSpec.describe BaseController, type: :controller do
       tax_year: tax_year)
   end
 
-  describe "#find_or_create_state_file_archived_intake" do
+  describe "#create_and_login_state_file_archived_intake" do
     before { session[:year_selected] = tax_year }
 
     context "when email_address is provided" do
       it "finds the intake by email and signs it in" do
-        controller.find_or_create_state_file_archived_intake(email_address: email_address)
+        controller.create_and_login_state_file_archived_intake(email_address: email_address)
         expect(controller.current_state_file_archived_intake).to eq(email_intake)
       end
 
       it "matches email case-insensitively" do
-        controller.find_or_create_state_file_archived_intake(email_address: "TeSt@ExAmPlE.CoM")
+        controller.create_and_login_state_file_archived_intake(email_address: "TeSt@ExAmPlE.CoM")
         expect(controller.current_state_file_archived_intake).to eq(email_intake)
       end
 
       it "does not match an intake with the same email in a different tax_year" do
         create(:state_file_archived_intake, email_address: email_address, tax_year: tax_year + 1)
-        controller.find_or_create_state_file_archived_intake(email_address: email_address)
+        controller.create_and_login_state_file_archived_intake(email_address: email_address)
         expect(controller.current_state_file_archived_intake).to eq(email_intake)
       end
 
@@ -49,7 +49,7 @@ RSpec.describe BaseController, type: :controller do
         create(:state_file_archived_intake, email_address: "new_email@domain.com", tax_year: tax_year + 1)
 
         expect {
-          controller.find_or_create_state_file_archived_intake(email_address: "new_email@domain.com")
+          controller.create_and_login_state_file_archived_intake(email_address: "new_email@domain.com")
         }.to change { StateFileArchivedIntake.count }.by(1)
 
         new_intake = controller.current_state_file_archived_intake
@@ -60,7 +60,7 @@ RSpec.describe BaseController, type: :controller do
 
       it "creates a new intake if email does not exist" do
         expect {
-          controller.find_or_create_state_file_archived_intake(email_address: "brand_new@domain.com")
+          controller.create_and_login_state_file_archived_intake(email_address: "brand_new@domain.com")
         }.to change { StateFileArchivedIntake.count }.by(1)
 
         new_intake = controller.current_state_file_archived_intake
@@ -71,13 +71,13 @@ RSpec.describe BaseController, type: :controller do
 
     context "when phone_number is provided" do
       it "finds the intake by phone and signs it in" do
-        controller.find_or_create_state_file_archived_intake(phone_number: phone_number)
+        controller.create_and_login_state_file_archived_intake(phone_number: phone_number)
         expect(controller.current_state_file_archived_intake).to eq(phone_intake)
       end
 
       it "does not match an intake with the same phone in a different tax_year" do
         create(:state_file_archived_intake, phone_number: phone_number, tax_year: tax_year + 1)
-        controller.find_or_create_state_file_archived_intake(phone_number: phone_number)
+        controller.create_and_login_state_file_archived_intake(phone_number: phone_number)
         expect(controller.current_state_file_archived_intake).to eq(phone_intake)
       end
 
@@ -85,7 +85,7 @@ RSpec.describe BaseController, type: :controller do
         create(:state_file_archived_intake, phone_number: "9998887777", tax_year: tax_year + 1)
 
         expect {
-          controller.find_or_create_state_file_archived_intake(phone_number: "9998887777")
+          controller.create_and_login_state_file_archived_intake(phone_number: "9998887777")
         }.to change { StateFileArchivedIntake.count }.by(1)
 
         new_intake = controller.current_state_file_archived_intake
@@ -96,7 +96,7 @@ RSpec.describe BaseController, type: :controller do
 
       it "creates a new intake if phone number does not exist" do
         expect {
-          controller.find_or_create_state_file_archived_intake(phone_number: "1112223333")
+          controller.create_and_login_state_file_archived_intake(phone_number: "1112223333")
         }.to change { StateFileArchivedIntake.count }.by(1)
 
         new_intake = controller.current_state_file_archived_intake
@@ -109,7 +109,7 @@ RSpec.describe BaseController, type: :controller do
       it "redirects to root and does not sign in or create" do
         expect(controller).to receive(:redirect_to).with("/")
         expect {
-          controller.find_or_create_state_file_archived_intake
+          controller.create_and_login_state_file_archived_intake
         }.not_to change { StateFileArchivedIntake.count }
         expect(controller.current_state_file_archived_intake).to be_nil
       end
@@ -121,7 +121,7 @@ RSpec.describe BaseController, type: :controller do
       it "redirects to root and does not create" do
         expect(controller).to receive(:redirect_to).with("/")
         expect {
-          controller.find_or_create_state_file_archived_intake(email_address: "y0@ex.com")
+          controller.create_and_login_state_file_archived_intake(email_address: "y0@ex.com")
         }.not_to change { StateFileArchivedIntake.count }
         expect(controller.current_state_file_archived_intake).to be_nil
       end

--- a/spec/controllers/base_controller_spec.rb
+++ b/spec/controllers/base_controller_spec.rb
@@ -1,170 +1,130 @@
+# spec/controllers/base_controller_spec.rb
 require "rails_helper"
 
-# describe BaseController, type: :controller do
-#   let(:email_address) { "test@example.com" }
-#   let(:phone_number) { "4153334444" }
-#   let(:tax_year) { 2023 }
-#
-#   before do
-#     session[:year_selected] = tax_year
-#   end
-#
-#   let!(:email_intake) { create :state_file_archived_intake, email_address: email_address }
-#   let!(:phone_intake) { create :state_file_archived_intake, phone_number: phone_number }
-#
-#   describe "#current_archived_intake" do
-#     context "when session has email_address" do
-#       before { session[:email_address] = email_address }
-#
-#       it "finds the intake by email" do
-#         expect(controller.current_archived_intake).to eq(email_intake)
-#       end
-#
-#       it "matches email case-insensitively" do
-#         session[:email_address] = "TeSt@ExAmPlE.cOm"
-#         expect(controller.current_archived_intake).to eq(email_intake)
-#       end
-#
-#       it "does not match an intake with the same email in a different tax_year" do
-#         other_year = tax_year + 1
-#         create :state_file_archived_intake, email_address: email_address, tax_year: other_year
-#
-#         expect(controller.current_archived_intake).to eq(email_intake)
-#       end
-#
-#       it "creates a new intake scoped to tax_year if email does not exist for that year" do
-#         create :state_file_archived_intake, email_address: "new_email@domain.com", tax_year: tax_year + 1
-#
-#         session[:email_address] = "new_email@domain.com"
-#
-#         expect {
-#           @new_intake = controller.current_archived_intake
-#         }.to change { StateFileArchivedIntake.count }.by(1)
-#
-#         expect(@new_intake.email_address).to eq("new_email@domain.com")
-#         expect(@new_intake.phone_number).to be_nil
-#         expect(@new_intake.tax_year).to eq(tax_year)
-#       end
-#
-#       it "creates a new intake if email does not exist" do
-#         session[:email_address] = "new_email@domain.com"
-#
-#         expect {
-#           @new_intake = controller.current_archived_intake
-#         }.to change { StateFileArchivedIntake.count }.by(1)
-#
-#         expect(@new_intake.email_address).to eq("new_email@domain.com")
-#         expect(@new_intake.phone_number).to be_nil
-#       end
-#     end
-#
-#     context "when session has phone_number" do
-#       before { session[:phone_number] = phone_number }
-#
-#       it "finds the intake by phone" do
-#         expect(controller.current_archived_intake).to eq(phone_intake)
-#       end
-#
-#       it "does not match an intake with the same phone in a different tax_year" do
-#         other_year = tax_year + 1
-#         create :state_file_archived_intake, phone_number: phone_number, tax_year: other_year
-#
-#         expect(controller.current_archived_intake).to eq(phone_intake)
-#       end
-#
-#       it "creates a new intake scoped to tax_year if phone number does not exist for that year" do
-#         create :state_file_archived_intake, phone_number: "9998887777", tax_year: tax_year + 1
-#
-#         session[:phone_number] = "9998887777"
-#
-#         expect {
-#           @new_intake = controller.current_archived_intake
-#         }.to change { StateFileArchivedIntake.count }.by(1)
-#
-#         expect(@new_intake.phone_number).to eq("9998887777")
-#         expect(@new_intake.email_address).to be_nil
-#         expect(@new_intake.tax_year).to eq(tax_year)
-#       end
-#
-#       it "creates a new intake if phone number does not exist" do
-#         session[:phone_number] = "9998887777"
-#
-#         expect {
-#           @new_intake = controller.current_archived_intake
-#         }.to change { StateFileArchivedIntake.count }.by(1)
-#
-#         expect(@new_intake.phone_number).to eq("9998887777")
-#         expect(@new_intake.email_address).to be_nil
-#       end
-#     end
-#
-#     context "when neither phone_number nor email_address is set" do
-#       it "returns nil" do
-#         expect(controller.current_archived_intake).to be_nil
-#       end
-#     end
-#
-#     context "when year_selected is nil" do
-#       before { session[:email_address] = email_address }
-#       before do
-#         session[:year_selected] = nil
-#       end
-#
-#       it "returns nil" do
-#         expect(controller.current_archived_intake).to be_nil
-#       end
-#     end
-#   end
-#
-#   describe "#is_intake_unavailable" do
-#     let!(:archived_intake) { create :state_file_archived_intake }
-#     before do
-#       allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-#     end
-#
-#     context "when the request is nil" do
-#       before do
-#         allow(controller).to receive(:current_archived_intake).and_return(nil)
-#       end
-#
-#       it "redirects to verification error page" do
-#         expect(controller).to receive(:redirect_to).with(knock_out_path)
-#         controller.is_intake_unavailable
-#       end
-#     end
-#
-#     context "when the request is locked" do
-#       before do
-#         allow(archived_intake).to receive(:access_locked?).and_return(true)
-#       end
-#
-#       it "redirects to verification error page" do
-#         expect(controller).to receive(:redirect_to).with(knock_out_path)
-#         controller.is_intake_unavailable
-#       end
-#     end
-#
-#     context "when the archived intake is permanently locked" do
-#       before do
-#         allow(archived_intake).to receive(:permanently_locked_at).and_return(Time.current)
-#       end
-#
-#       it "redirects to verification error page" do
-#         expect(controller).to receive(:redirect_to).with(knock_out_path)
-#         controller.is_intake_unavailable
-#       end
-#     end
-#
-#     context "when the request is valid and not locked" do
-#       before do
-#         allow(archived_intake).to receive(:access_locked?).and_return(false)
-#         allow(archived_intake).to receive(:permanently_locked_at).and_return(nil)
-#       end
-#
-#       it "does not redirect" do
-#         expect(controller).not_to receive(:redirect_to)
-#         controller.is_intake_unavailable
-#       end
-#     end
-#   end
-# end
+RSpec.describe BaseController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+    allow(controller).to receive(:root_path).and_return("/")
+  end
+
+  let(:tax_year) { 2024 }
+  let(:email_address) { "test@example.com" }
+  let(:phone_number) { "5551234567" }
+
+  let!(:email_intake) do
+    create(:state_file_archived_intake,
+      email_address: email_address,
+      tax_year: tax_year)
+  end
+
+  let!(:phone_intake) do
+    create(:state_file_archived_intake,
+      phone_number: phone_number,
+      tax_year: tax_year)
+  end
+
+  describe "#find_or_create_state_file_archived_intake" do
+    before { session[:year_selected] = tax_year }
+
+    context "when email_address is provided" do
+      it "finds the intake by email and signs it in" do
+        controller.find_or_create_state_file_archived_intake(email_address: email_address)
+        expect(controller.current_state_file_archived_intake).to eq(email_intake)
+      end
+
+      it "matches email case-insensitively" do
+        controller.find_or_create_state_file_archived_intake(email_address: "TeSt@ExAmPlE.CoM")
+        expect(controller.current_state_file_archived_intake).to eq(email_intake)
+      end
+
+      it "does not match an intake with the same email in a different tax_year" do
+        create(:state_file_archived_intake, email_address: email_address, tax_year: tax_year + 1)
+        controller.find_or_create_state_file_archived_intake(email_address: email_address)
+        expect(controller.current_state_file_archived_intake).to eq(email_intake)
+      end
+
+      it "creates a new intake scoped to tax_year if email does not exist for that year" do
+        create(:state_file_archived_intake, email_address: "new_email@domain.com", tax_year: tax_year + 1)
+
+        expect {
+          controller.find_or_create_state_file_archived_intake(email_address: "new_email@domain.com")
+        }.to change { StateFileArchivedIntake.count }.by(1)
+
+        new_intake = controller.current_state_file_archived_intake
+        expect(new_intake.email_address).to eq("new_email@domain.com")
+        expect(new_intake.phone_number).to be_nil
+        expect(new_intake.tax_year).to eq(tax_year)
+      end
+
+      it "creates a new intake if email does not exist" do
+        expect {
+          controller.find_or_create_state_file_archived_intake(email_address: "brand_new@domain.com")
+        }.to change { StateFileArchivedIntake.count }.by(1)
+
+        new_intake = controller.current_state_file_archived_intake
+        expect(new_intake.email_address).to eq("brand_new@domain.com")
+        expect(new_intake.phone_number).to be_nil
+      end
+    end
+
+    context "when phone_number is provided" do
+      it "finds the intake by phone and signs it in" do
+        controller.find_or_create_state_file_archived_intake(phone_number: phone_number)
+        expect(controller.current_state_file_archived_intake).to eq(phone_intake)
+      end
+
+      it "does not match an intake with the same phone in a different tax_year" do
+        create(:state_file_archived_intake, phone_number: phone_number, tax_year: tax_year + 1)
+        controller.find_or_create_state_file_archived_intake(phone_number: phone_number)
+        expect(controller.current_state_file_archived_intake).to eq(phone_intake)
+      end
+
+      it "creates a new intake scoped to tax_year if phone number does not exist for that year" do
+        create(:state_file_archived_intake, phone_number: "9998887777", tax_year: tax_year + 1)
+
+        expect {
+          controller.find_or_create_state_file_archived_intake(phone_number: "9998887777")
+        }.to change { StateFileArchivedIntake.count }.by(1)
+
+        new_intake = controller.current_state_file_archived_intake
+        expect(new_intake.phone_number).to eq("9998887777")
+        expect(new_intake.email_address).to be_nil
+        expect(new_intake.tax_year).to eq(tax_year)
+      end
+
+      it "creates a new intake if phone number does not exist" do
+        expect {
+          controller.find_or_create_state_file_archived_intake(phone_number: "1112223333")
+        }.to change { StateFileArchivedIntake.count }.by(1)
+
+        new_intake = controller.current_state_file_archived_intake
+        expect(new_intake.phone_number).to eq("1112223333")
+        expect(new_intake.email_address).to be_nil
+      end
+    end
+
+    context "when neither phone_number nor email_address is provided" do
+      it "redirects to root and does not sign in or create" do
+        expect(controller).to receive(:redirect_to).with("/")
+        expect {
+          controller.find_or_create_state_file_archived_intake
+        }.not_to change { StateFileArchivedIntake.count }
+        expect(controller.current_state_file_archived_intake).to be_nil
+      end
+    end
+
+    context "when year_selected is nil" do
+      before { session[:year_selected] = nil }
+
+      it "redirects to root and does not create" do
+        expect(controller).to receive(:redirect_to).with("/")
+        expect {
+          controller.find_or_create_state_file_archived_intake(email_address: "y0@ex.com")
+        }.not_to change { StateFileArchivedIntake.count }
+        expect(controller.current_state_file_archived_intake).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/email_address_controller_spec.rb
+++ b/spec/controllers/email_address_controller_spec.rb
@@ -1,6 +1,13 @@
+# spec/controllers/email_address_controller_spec.rb
 require "rails_helper"
 
 RSpec.describe EmailAddressController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+  end
+
   describe "GET #edit" do
     it "renders the edit template with a new EmailAddressForm" do
       get :edit
@@ -16,88 +23,89 @@ RSpec.describe EmailAddressController, type: :controller do
     let(:invalid_email_address) { "" }
 
     context "when the form is valid" do
-      before do
-        session[:year_selected] = "2023"
-      end
-      context "and an archived intake exists with an email address" do
-        let!(:archived_intake) { create :state_file_archived_intake, email_address: valid_email_address, tax_year: 2023 }
-        # TODO update this test with logging and the proper redirects https://codeforamerica.atlassian.net/browse/FYST-2088
-        it "creates a request, updates the session, redirects to the verification code path and calls sign in with the existing intake" do
+      before { session[:year_selected] = "2023" }
+
+      context "and an archived intake exists with that email (case-insensitive)" do
+        let!(:archived_intake) do
+          create(:state_file_archived_intake, email_address: valid_email_address, tax_year: 2023)
+        end
+
+        it "finds the existing intake, signs it in, resets flags, and redirects to verification code" do
           expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
-          post :update, params: {
-            email_address_form: {email_address: valid_email_address}
-          }
+
+          post :update, params: {email_address_form: {email_address: valid_email_address}}
+
           expect(assigns(:form)).to be_valid
-          active_archived_intake = controller.send(:current_archived_intake)
-          expect(active_archived_intake.email_address).to eq(valid_email_address)
-          expect(active_archived_intake.hashed_ssn).to eq(archived_intake.hashed_ssn)
-          expect(active_archived_intake.id).to eq(archived_intake.id)
+
+          active = controller.current_state_file_archived_intake
+          expect(active.id).to eq(archived_intake.id)
+          expect(active.email_address).to eq(valid_email_address)
 
           expect(session[:ssn_verified]).to be(false)
           expect(session[:mailing_verified]).to be(false)
           expect(session[:code_verified]).to be(false)
-          expect(session[:email_address]).to eq(valid_email_address)
+          expect(session[:email_address]).to be_nil
 
           expect(response).to redirect_to(edit_verification_code_path)
         end
 
-        it "matches email case insensitively" do
-          post :update, params: {
-            email_address_form: {email_address: mixed_case_email_address}
-          }
+        it "matches email case-insensitively" do
+          post :update, params: {email_address_form: {email_address: mixed_case_email_address}}
 
           expect(assigns(:form)).to be_valid
 
-          active_archived_intake = controller.send(:current_archived_intake)
-          expect(active_archived_intake.email_address).to eq(valid_email_address)
-          expect(active_archived_intake.hashed_ssn).to eq(archived_intake.hashed_ssn)
-          expect(active_archived_intake.id).to eq(archived_intake.id)
+          active = controller.current_state_file_archived_intake
+          expect(active.id).to eq(archived_intake.id)
+          expect(active.email_address).to eq(valid_email_address)
 
           expect(response).to redirect_to(edit_verification_code_path)
         end
       end
 
       context "and an archived intake does not exist with the email address" do
-        it "creates an access log, creates a new archived intake without a ssn or address, redirects to the verification code page and calls sign in with the existing intake" do
-          expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
-          post :update, params: {
-            email_address_form: {email_address: valid_email_address}
-          }
-          expect(assigns(:form)).to be_valid
-
-          active_archived_intake = controller.send(:current_archived_intake)
-          expect(active_archived_intake.email_address).to eq(valid_email_address)
-          expect(active_archived_intake.hashed_ssn).to eq(nil)
-          expect(active_archived_intake.full_address).to eq("")
-
-          expect(response).to redirect_to(edit_verification_code_path)
-        end
-
-        it "resets verification session variables and sets email" do
-          post :update, params: {
-            email_address_form: {email_address: valid_email_address}
-          }
+        it "creates a new intake for the year, signs it in, resets flags, and redirects" do
+          expect {
+            post :update, params: {email_address_form: {email_address: valid_email_address}}
+          }.to change { StateFileArchivedIntake.count }.by(1)
 
           expect(assigns(:form)).to be_valid
+
+          active = controller.current_state_file_archived_intake
+          expect(active.email_address).to eq(valid_email_address)
+          expect(active.tax_year).to eq(2023)
+          expect(active.hashed_ssn).to be_nil
+          expect(active.full_address).to eq("")
 
           expect(session[:ssn_verified]).to be(false)
           expect(session[:mailing_verified]).to be(false)
           expect(session[:code_verified]).to be(false)
+          expect(session[:email_address]).to be_nil
 
-          expect(session[:email_address]).to eq(valid_email_address)
+          expect(response).to redirect_to(edit_verification_code_path)
         end
       end
     end
 
     context "when the form is invalid" do
       it "renders the edit template" do
-        post :update, params: {
-          email_address_form: {email_address: invalid_email_address}
-        }
-
+        post :update, params: {email_address_form: {email_address: invalid_email_address}}
         expect(assigns(:form)).not_to be_valid
-
         expect(response).to render_template(:edit)
+      end
+    end
+
+    context "when year_selected is missing" do
+      before { session[:year_selected] = nil }
+
+      it "redirects to root (via BaseController) and does not create or sign in" do
+        expect(controller).to receive(:redirect_to).with("/en").and_call_original
+
+        expect {
+          post :update, params: {email_address_form: {email_address: valid_email_address}}
+        }.not_to change { StateFileArchivedIntake.count }
+
+        expect(controller.current_state_file_archived_intake).to be_nil
+        expect(response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/controllers/identification_number_controller_spec.rb
+++ b/spec/controllers/identification_number_controller_spec.rb
@@ -1,97 +1,111 @@
-# require "rails_helper"
-#
-# RSpec.describe IdentificationNumberController, type: :controller do
-#   let(:intake_ssn) { "123456789" }
-#   let(:invalid_ssn) { "212345678" }
-#   let(:intake_request_email) { "ohhithere@gmail.com" }
-#   let(:hashed_ssn) { SsnHashingService.hash(intake_ssn) }
-#   let!(:archived_intake) { create(:state_file_archived_intake, hashed_ssn: hashed_ssn, email_address: intake_request_email, failed_attempts: 0) }
-#
-#   before do
-#     session[:code_verified] = true
-#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-#     session[:email_address] = "ohhithere@example.com"
-#     sign_in_archived_intake(archived_intake)
-#
-#     allow(EventLogger).to receive(:log)
-#   end
-#
-#   describe "GET #edit" do
-#     it_behaves_like "archived intake locked", action: :edit, method: :get
-#     it_behaves_like "an authenticated archived intake controller", :get, :edit
-#
-#     it "renders the edit template with a new IdentificationNumberForm" do
-#       get :edit
-#
-#       expect(assigns(:form)).to be_a(IdentificationNumberForm)
-#       expect(response).to render_template(:edit)
-#     end
-#
-#     it "redirects to root if code verification was not completed and logs unauthorized attempt" do
-#       session[:code_verified] = nil
-#
-#       get :edit
-#
-#       expect(EventLogger).to have_received(:log).with("unauthorized ssn attempt", archived_intake.id)
-#       expect(response).to redirect_to(root_path)
-#     end
-#   end
-#
-#   describe "PATCH #update" do
-#     it_behaves_like "an authenticated archived intake controller", :patch, :update
-#
-#     context "with a valid ssn" do
-#       it "redirects to the mailing address validation page and logs success + next challenge" do
-#         expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
-#         expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
-#
-#         post :update, params: {
-#           identification_number_form: {ssn: intake_ssn}
-#         }
-#
-#         expect(assigns(:form)).to be_valid
-#         expect(session[:ssn_verified]).to eq(true)
-#         expect(archived_intake.reload.failed_attempts).to eq(0)
-#         expect(response).to redirect_to(edit_mailing_address_validation_path)
-#       end
-#
-#       it "resets failed attempts to zero even if one failed attempt has already been made" do
-#         archived_intake.update!(failed_attempts: 1)
-#
-#         expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
-#         expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
-#
-#         post :update, params: {
-#           identification_number_form: {ssn: intake_ssn}
-#         }
-#
-#         expect(assigns(:form)).to be_valid
-#         expect(archived_intake.reload.failed_attempts).to eq(0)
-#       end
-#     end
-#
-#     context "with an invalid ssn" do
-#       it "increments failed_attempts, logs incorrect attempt, and re-renders edit on first failed attempt" do
-#         expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id)
-#
-#         post :update, params: {identification_number_form: {ssn: invalid_ssn}}
-#
-#         expect(archived_intake.reload.failed_attempts).to eq(1)
-#         expect(response).to render_template(:edit)
-#       end
-#
-#       it "locks the account, logs lockout begin, and redirects to knock out after multiple failed attempts" do
-#         archived_intake.update!(failed_attempts: 1)
-#
-#         expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id).ordered
-#         expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
-#
-#         post :update, params: {identification_number_form: {ssn: invalid_ssn}}
-#
-#         expect(archived_intake.reload.failed_attempts).to eq(2)
-#         expect(archived_intake.reload.access_locked?).to be_truthy
-#         expect(response).to redirect_to(knock_out_path)
-#       end
-#     end
-#   end
-# end
+require "rails_helper"
+
+RSpec.describe IdentificationNumberController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  let(:intake_ssn) { "123456789" }
+  let(:invalid_ssn) { "212345678" }
+  let(:intake_request_email) { "ohhithere@gmail.com" }
+  let(:hashed_ssn) { SsnHashingService.hash(intake_ssn) }
+
+  let!(:archived_intake) do
+    create(
+      :state_file_archived_intake,
+      hashed_ssn: hashed_ssn,
+      email_address: intake_request_email,
+      failed_attempts: 0
+    )
+  end
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+
+    sign_in archived_intake
+
+    session[:code_verified] = true
+
+    allow(EventLogger).to receive(:log)
+  end
+
+  describe "GET #edit" do
+    it "renders the edit template with a new IdentificationNumberForm bound to the current intake" do
+      get :edit
+
+      expect(assigns(:form)).to be_a(IdentificationNumberForm)
+      expect(response).to render_template(:edit)
+    end
+
+    it "redirects to root if code verification was not completed and logs unauthorized attempt" do
+      session[:code_verified] = nil
+
+      get :edit
+
+      expect(EventLogger).to have_received(:log).with("unauthorized ssn attempt", archived_intake.id)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "PATCH #update" do
+    context "with a valid ssn" do
+      it "redirects to mailing address validation, logs success + next challenge, resets failed attempts, and sets ssn_verified" do
+        expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
+        expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
+
+        post :update, params: {identification_number_form: {ssn: intake_ssn}}
+
+        expect(assigns(:form)).to be_valid
+        expect(session[:ssn_verified]).to eq(true)
+        expect(archived_intake.reload.failed_attempts).to eq(0)
+        expect(response).to redirect_to(edit_mailing_address_validation_path)
+      end
+
+      it "resets failed attempts to zero even if one failed attempt has already been made" do
+        archived_intake.update!(failed_attempts: 1)
+
+        expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
+        expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
+
+        post :update, params: {identification_number_form: {ssn: intake_ssn}}
+
+        expect(assigns(:form)).to be_valid
+        expect(archived_intake.reload.failed_attempts).to eq(0)
+      end
+    end
+
+    context "with an invalid ssn" do
+      it "increments failed_attempts, logs incorrect attempt, and re-renders edit on first failed attempt" do
+        expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id)
+
+        post :update, params: {identification_number_form: {ssn: invalid_ssn}}
+
+        expect(archived_intake.reload.failed_attempts).to eq(1)
+        expect(response).to render_template(:edit)
+      end
+
+      it "locks the account after subsequent failures, logs lockout begin, and redirects to knock_out" do
+        archived_intake.update!(failed_attempts: 1)
+
+        expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id).ordered
+        expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
+
+        post :update, params: {identification_number_form: {ssn: invalid_ssn}}
+
+        archived_intake.reload
+        expect(archived_intake.failed_attempts).to eq(2)
+        expect(archived_intake.access_locked?).to be_truthy
+        expect(response).to redirect_to(knock_out_path)
+      end
+    end
+
+    context "when code verification is missing" do
+      it "redirects to root (guard in before_action) and logs unauthorized attempt" do
+        session[:code_verified] = nil
+
+        post :update, params: {identification_number_form: {ssn: intake_ssn}}
+
+        expect(EventLogger).to have_received(:log).with("unauthorized ssn attempt", archived_intake.id)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/identification_number_controller_spec.rb
+++ b/spec/controllers/identification_number_controller_spec.rb
@@ -1,97 +1,97 @@
-require "rails_helper"
-
-RSpec.describe IdentificationNumberController, type: :controller do
-  let(:intake_ssn) { "123456789" }
-  let(:invalid_ssn) { "212345678" }
-  let(:intake_request_email) { "ohhithere@gmail.com" }
-  let(:hashed_ssn) { SsnHashingService.hash(intake_ssn) }
-  let!(:archived_intake) { create(:state_file_archived_intake, hashed_ssn: hashed_ssn, email_address: intake_request_email, failed_attempts: 0) }
-
-  before do
-    session[:code_verified] = true
-    allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-    session[:email_address] = "ohhithere@example.com"
-    sign_in_archived_intake(archived_intake)
-
-    allow(EventLogger).to receive(:log)
-  end
-
-  describe "GET #edit" do
-    it_behaves_like "archived intake locked", action: :edit, method: :get
-    it_behaves_like "an authenticated archived intake controller", :get, :edit
-
-    it "renders the edit template with a new IdentificationNumberForm" do
-      get :edit
-
-      expect(assigns(:form)).to be_a(IdentificationNumberForm)
-      expect(response).to render_template(:edit)
-    end
-
-    it "redirects to root if code verification was not completed and logs unauthorized attempt" do
-      session[:code_verified] = nil
-
-      get :edit
-
-      expect(EventLogger).to have_received(:log).with("unauthorized ssn attempt", archived_intake.id)
-      expect(response).to redirect_to(root_path)
-    end
-  end
-
-  describe "PATCH #update" do
-    it_behaves_like "an authenticated archived intake controller", :patch, :update
-
-    context "with a valid ssn" do
-      it "redirects to the mailing address validation page and logs success + next challenge" do
-        expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
-        expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
-
-        post :update, params: {
-          identification_number_form: {ssn: intake_ssn}
-        }
-
-        expect(assigns(:form)).to be_valid
-        expect(session[:ssn_verified]).to eq(true)
-        expect(archived_intake.reload.failed_attempts).to eq(0)
-        expect(response).to redirect_to(edit_mailing_address_validation_path)
-      end
-
-      it "resets failed attempts to zero even if one failed attempt has already been made" do
-        archived_intake.update!(failed_attempts: 1)
-
-        expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
-        expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
-
-        post :update, params: {
-          identification_number_form: {ssn: intake_ssn}
-        }
-
-        expect(assigns(:form)).to be_valid
-        expect(archived_intake.reload.failed_attempts).to eq(0)
-      end
-    end
-
-    context "with an invalid ssn" do
-      it "increments failed_attempts, logs incorrect attempt, and re-renders edit on first failed attempt" do
-        expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id)
-
-        post :update, params: {identification_number_form: {ssn: invalid_ssn}}
-
-        expect(archived_intake.reload.failed_attempts).to eq(1)
-        expect(response).to render_template(:edit)
-      end
-
-      it "locks the account, logs lockout begin, and redirects to knock out after multiple failed attempts" do
-        archived_intake.update!(failed_attempts: 1)
-
-        expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id).ordered
-        expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
-
-        post :update, params: {identification_number_form: {ssn: invalid_ssn}}
-
-        expect(archived_intake.reload.failed_attempts).to eq(2)
-        expect(archived_intake.reload.access_locked?).to be_truthy
-        expect(response).to redirect_to(knock_out_path)
-      end
-    end
-  end
-end
+# require "rails_helper"
+#
+# RSpec.describe IdentificationNumberController, type: :controller do
+#   let(:intake_ssn) { "123456789" }
+#   let(:invalid_ssn) { "212345678" }
+#   let(:intake_request_email) { "ohhithere@gmail.com" }
+#   let(:hashed_ssn) { SsnHashingService.hash(intake_ssn) }
+#   let!(:archived_intake) { create(:state_file_archived_intake, hashed_ssn: hashed_ssn, email_address: intake_request_email, failed_attempts: 0) }
+#
+#   before do
+#     session[:code_verified] = true
+#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
+#     session[:email_address] = "ohhithere@example.com"
+#     sign_in_archived_intake(archived_intake)
+#
+#     allow(EventLogger).to receive(:log)
+#   end
+#
+#   describe "GET #edit" do
+#     it_behaves_like "archived intake locked", action: :edit, method: :get
+#     it_behaves_like "an authenticated archived intake controller", :get, :edit
+#
+#     it "renders the edit template with a new IdentificationNumberForm" do
+#       get :edit
+#
+#       expect(assigns(:form)).to be_a(IdentificationNumberForm)
+#       expect(response).to render_template(:edit)
+#     end
+#
+#     it "redirects to root if code verification was not completed and logs unauthorized attempt" do
+#       session[:code_verified] = nil
+#
+#       get :edit
+#
+#       expect(EventLogger).to have_received(:log).with("unauthorized ssn attempt", archived_intake.id)
+#       expect(response).to redirect_to(root_path)
+#     end
+#   end
+#
+#   describe "PATCH #update" do
+#     it_behaves_like "an authenticated archived intake controller", :patch, :update
+#
+#     context "with a valid ssn" do
+#       it "redirects to the mailing address validation page and logs success + next challenge" do
+#         expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
+#         expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
+#
+#         post :update, params: {
+#           identification_number_form: {ssn: intake_ssn}
+#         }
+#
+#         expect(assigns(:form)).to be_valid
+#         expect(session[:ssn_verified]).to eq(true)
+#         expect(archived_intake.reload.failed_attempts).to eq(0)
+#         expect(response).to redirect_to(edit_mailing_address_validation_path)
+#       end
+#
+#       it "resets failed attempts to zero even if one failed attempt has already been made" do
+#         archived_intake.update!(failed_attempts: 1)
+#
+#         expect(EventLogger).to receive(:log).with("correct ssn challenge", archived_intake.id).ordered
+#         expect(EventLogger).to receive(:log).with("issued mailing address challenge", archived_intake.id).ordered
+#
+#         post :update, params: {
+#           identification_number_form: {ssn: intake_ssn}
+#         }
+#
+#         expect(assigns(:form)).to be_valid
+#         expect(archived_intake.reload.failed_attempts).to eq(0)
+#       end
+#     end
+#
+#     context "with an invalid ssn" do
+#       it "increments failed_attempts, logs incorrect attempt, and re-renders edit on first failed attempt" do
+#         expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id)
+#
+#         post :update, params: {identification_number_form: {ssn: invalid_ssn}}
+#
+#         expect(archived_intake.reload.failed_attempts).to eq(1)
+#         expect(response).to render_template(:edit)
+#       end
+#
+#       it "locks the account, logs lockout begin, and redirects to knock out after multiple failed attempts" do
+#         archived_intake.update!(failed_attempts: 1)
+#
+#         expect(EventLogger).to receive(:log).with("incorrect ssn challenge", archived_intake.id).ordered
+#         expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
+#
+#         post :update, params: {identification_number_form: {ssn: invalid_ssn}}
+#
+#         expect(archived_intake.reload.failed_attempts).to eq(2)
+#         expect(archived_intake.reload.access_locked?).to be_truthy
+#         expect(response).to redirect_to(knock_out_path)
+#       end
+#     end
+#   end
+# end

--- a/spec/controllers/mailing_address_validation_controller_spec.rb
+++ b/spec/controllers/mailing_address_validation_controller_spec.rb
@@ -1,93 +1,107 @@
-# require "rails_helper"
-#
-# RSpec.describe MailingAddressValidationController, type: :controller do
-#   let(:archived_intake) { create(:state_file_archived_intake, mailing_state: "NY") }
-#   let(:email_address) { "test@example.com" }
-#   let(:valid_verification_code) { "123456" }
-#   let(:invalid_verification_code) { "654321" }
-#
-#   before do
-#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-#     allow(I18n).to receive(:locale).and_return(:en)
-#     session[:code_verified] = true
-#     session[:ssn_verified] = true
-#     sign_in_archived_intake(archived_intake)
-#     allow(EventLogger).to receive(:log)
-#   end
-#
-#   describe "GET #edit" do
-#     it_behaves_like "archived intake locked", action: :edit, method: :get
-#     it_behaves_like "an authenticated archived intake controller", :get, :edit
-#
-#     context "when the request is locked" do
-#       before do
-#         allow(archived_intake).to receive(:access_locked?).and_return(true)
-#       end
-#     end
-#
-#     context "when the request is not locked" do
-#       before do
-#         allow(archived_intake).to receive(:access_locked?).and_return(false)
-#       end
-#
-#       it "renders the edit template with a new MailingAddressValidationForm" do
-#         get :edit
-#         expect(assigns(:form)).to be_a(MailingAddressValidationForm)
-#         expect(response).to render_template(:edit)
-#       end
-#     end
-#
-#     it "redirects to root if code verification was not completed" do
-#       session[:code_verified] = nil
-#       session[:ssn_verified] = true
-#       get :edit
-#       expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
-#       expect(response).to redirect_to(root_path)
-#     end
-#
-#     it "redirects to root if ssn verification was not completed" do
-#       session[:code_verified] = true
-#       session[:ssn_verified] = nil
-#       get :edit
-#       expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
-#       expect(response).to redirect_to(root_path)
-#     end
-#   end
-#
-#   describe "PATCH #update" do
-#     it_behaves_like "an authenticated archived intake controller", :patch, :update
-#
-#     context "with a valid chosen address" do
-#       it "redirects to pdf index path" do
-#         expect(EventLogger).to receive(:log).with("correct mailing address", archived_intake.id)
-#         post :update, params: {
-#           mailing_address_validation_form: {selected_address: archived_intake.full_address, addresses: archived_intake.address_challenge_set}
-#         }
-#         expect(assigns(:form)).to be_valid
-#         expect(session[:mailing_verified]).to eq(true)
-#         expect(response).to redirect_to(pdf_index_path)
-#       end
-#     end
-#
-#     context "with an invalid chosen address" do
-#       it "locks the request and redirects to the verification error path" do
-#         expect(EventLogger).to receive(:log).with("incorrect mailing address", archived_intake.id)
-#         post :update, params: {
-#           mailing_address_validation_form: {selected_address: archived_intake.fake_address_1, addresses: archived_intake.address_challenge_set}
-#         }
-#         expect(assigns(:form)).not_to be_valid
-#         expect(session[:mailing_verified]).to eq(nil)
-#         expect(archived_intake.permanently_locked_at).to be_present
-#         expect(response).to redirect_to(knock_out_path)
-#       end
-#     end
-#
-#     context "without a chosen address" do
-#       it "re-renders the edit template" do
-#         post :update, params: {}
-#         expect(assigns(:form)).not_to be_valid
-#         expect(response).to render_template(:edit)
-#       end
-#     end
-#   end
-# end
+require "rails_helper"
+
+RSpec.describe MailingAddressValidationController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  let(:archived_intake) { create(:state_file_archived_intake, mailing_state: "NY") }
+  let(:email_address) { "test@example.com" } # kept in case shared examples reference it
+  let(:valid_code) { "123456" }
+  let(:invalid_code) { "654321" }
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+    sign_in archived_intake
+
+    session[:code_verified] = true
+    session[:ssn_verified] = true
+
+    allow(EventLogger).to receive(:log)
+  end
+
+  describe "GET #edit" do
+    it_behaves_like "archived intake locked", action: :edit, method: :get
+    it_behaves_like "an authenticated archived intake controller", :get, :edit
+
+    context "when the request is locked" do
+      before { allow(archived_intake).to receive(:access_locked?).and_return(true) }
+    end
+
+    context "when the request is not locked" do
+      before { allow(archived_intake).to receive(:access_locked?).and_return(false) }
+
+      it "renders the edit template with a new MailingAddressValidationForm" do
+        get :edit
+        expect(assigns(:form)).to be_a(MailingAddressValidationForm)
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    it "redirects to root if code verification was not completed" do
+      session[:code_verified] = nil
+      session[:ssn_verified] = true
+
+      get :edit
+
+      expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "redirects to root if ssn verification was not completed" do
+      session[:code_verified] = true
+      session[:ssn_verified] = nil
+
+      get :edit
+
+      expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "PATCH #update" do
+    it_behaves_like "an authenticated archived intake controller", :patch, :update
+
+    context "with a valid chosen address" do
+      it "logs success, sets mailing_verified, and redirects to pdf index path" do
+        expect(EventLogger).to receive(:log).with("correct mailing address", archived_intake.id)
+
+        post :update, params: {
+          mailing_address_validation_form: {
+            selected_address: archived_intake.full_address,
+            addresses: archived_intake.address_challenge_set # ignored by strong params but fine to pass
+          }
+        }
+
+        expect(assigns(:form)).to be_valid
+        expect(session[:mailing_verified]).to eq(true)
+        expect(response).to redirect_to(pdf_index_path)
+      end
+    end
+
+    context "with an invalid chosen address" do
+      it "logs incorrect attempt, permanently locks intake, and redirects to knock out" do
+        expect(EventLogger).to receive(:log).with("incorrect mailing address", archived_intake.id)
+
+        post :update, params: {
+          mailing_address_validation_form: {
+            selected_address: archived_intake.fake_address_1,
+            addresses: archived_intake.address_challenge_set
+          }
+        }
+
+        expect(assigns(:form)).not_to be_valid
+        expect(session[:mailing_verified]).to be_nil
+        expect(archived_intake.reload.permanently_locked_at).to be_present
+        expect(response).to redirect_to(knock_out_path)
+      end
+    end
+
+    context "without a chosen address" do
+      it "re-renders the edit template" do
+        post :update, params: {}
+
+        expect(assigns(:form)).not_to be_valid
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/mailing_address_validation_controller_spec.rb
+++ b/spec/controllers/mailing_address_validation_controller_spec.rb
@@ -1,93 +1,93 @@
-require "rails_helper"
-
-RSpec.describe MailingAddressValidationController, type: :controller do
-  let(:archived_intake) { create(:state_file_archived_intake, mailing_state: "NY") }
-  let(:email_address) { "test@example.com" }
-  let(:valid_verification_code) { "123456" }
-  let(:invalid_verification_code) { "654321" }
-
-  before do
-    allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-    allow(I18n).to receive(:locale).and_return(:en)
-    session[:code_verified] = true
-    session[:ssn_verified] = true
-    sign_in_archived_intake(archived_intake)
-    allow(EventLogger).to receive(:log)
-  end
-
-  describe "GET #edit" do
-    it_behaves_like "archived intake locked", action: :edit, method: :get
-    it_behaves_like "an authenticated archived intake controller", :get, :edit
-
-    context "when the request is locked" do
-      before do
-        allow(archived_intake).to receive(:access_locked?).and_return(true)
-      end
-    end
-
-    context "when the request is not locked" do
-      before do
-        allow(archived_intake).to receive(:access_locked?).and_return(false)
-      end
-
-      it "renders the edit template with a new MailingAddressValidationForm" do
-        get :edit
-        expect(assigns(:form)).to be_a(MailingAddressValidationForm)
-        expect(response).to render_template(:edit)
-      end
-    end
-
-    it "redirects to root if code verification was not completed" do
-      session[:code_verified] = nil
-      session[:ssn_verified] = true
-      get :edit
-      expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
-      expect(response).to redirect_to(root_path)
-    end
-
-    it "redirects to root if ssn verification was not completed" do
-      session[:code_verified] = true
-      session[:ssn_verified] = nil
-      get :edit
-      expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
-      expect(response).to redirect_to(root_path)
-    end
-  end
-
-  describe "PATCH #update" do
-    it_behaves_like "an authenticated archived intake controller", :patch, :update
-
-    context "with a valid chosen address" do
-      it "redirects to pdf index path" do
-        expect(EventLogger).to receive(:log).with("correct mailing address", archived_intake.id)
-        post :update, params: {
-          mailing_address_validation_form: {selected_address: archived_intake.full_address, addresses: archived_intake.address_challenge_set}
-        }
-        expect(assigns(:form)).to be_valid
-        expect(session[:mailing_verified]).to eq(true)
-        expect(response).to redirect_to(pdf_index_path)
-      end
-    end
-
-    context "with an invalid chosen address" do
-      it "locks the request and redirects to the verification error path" do
-        expect(EventLogger).to receive(:log).with("incorrect mailing address", archived_intake.id)
-        post :update, params: {
-          mailing_address_validation_form: {selected_address: archived_intake.fake_address_1, addresses: archived_intake.address_challenge_set}
-        }
-        expect(assigns(:form)).not_to be_valid
-        expect(session[:mailing_verified]).to eq(nil)
-        expect(archived_intake.permanently_locked_at).to be_present
-        expect(response).to redirect_to(knock_out_path)
-      end
-    end
-
-    context "without a chosen address" do
-      it "re-renders the edit template" do
-        post :update, params: {}
-        expect(assigns(:form)).not_to be_valid
-        expect(response).to render_template(:edit)
-      end
-    end
-  end
-end
+# require "rails_helper"
+#
+# RSpec.describe MailingAddressValidationController, type: :controller do
+#   let(:archived_intake) { create(:state_file_archived_intake, mailing_state: "NY") }
+#   let(:email_address) { "test@example.com" }
+#   let(:valid_verification_code) { "123456" }
+#   let(:invalid_verification_code) { "654321" }
+#
+#   before do
+#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
+#     allow(I18n).to receive(:locale).and_return(:en)
+#     session[:code_verified] = true
+#     session[:ssn_verified] = true
+#     sign_in_archived_intake(archived_intake)
+#     allow(EventLogger).to receive(:log)
+#   end
+#
+#   describe "GET #edit" do
+#     it_behaves_like "archived intake locked", action: :edit, method: :get
+#     it_behaves_like "an authenticated archived intake controller", :get, :edit
+#
+#     context "when the request is locked" do
+#       before do
+#         allow(archived_intake).to receive(:access_locked?).and_return(true)
+#       end
+#     end
+#
+#     context "when the request is not locked" do
+#       before do
+#         allow(archived_intake).to receive(:access_locked?).and_return(false)
+#       end
+#
+#       it "renders the edit template with a new MailingAddressValidationForm" do
+#         get :edit
+#         expect(assigns(:form)).to be_a(MailingAddressValidationForm)
+#         expect(response).to render_template(:edit)
+#       end
+#     end
+#
+#     it "redirects to root if code verification was not completed" do
+#       session[:code_verified] = nil
+#       session[:ssn_verified] = true
+#       get :edit
+#       expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
+#       expect(response).to redirect_to(root_path)
+#     end
+#
+#     it "redirects to root if ssn verification was not completed" do
+#       session[:code_verified] = true
+#       session[:ssn_verified] = nil
+#       get :edit
+#       expect(EventLogger).to have_received(:log).with("unauthorized mailing attempt", archived_intake.id)
+#       expect(response).to redirect_to(root_path)
+#     end
+#   end
+#
+#   describe "PATCH #update" do
+#     it_behaves_like "an authenticated archived intake controller", :patch, :update
+#
+#     context "with a valid chosen address" do
+#       it "redirects to pdf index path" do
+#         expect(EventLogger).to receive(:log).with("correct mailing address", archived_intake.id)
+#         post :update, params: {
+#           mailing_address_validation_form: {selected_address: archived_intake.full_address, addresses: archived_intake.address_challenge_set}
+#         }
+#         expect(assigns(:form)).to be_valid
+#         expect(session[:mailing_verified]).to eq(true)
+#         expect(response).to redirect_to(pdf_index_path)
+#       end
+#     end
+#
+#     context "with an invalid chosen address" do
+#       it "locks the request and redirects to the verification error path" do
+#         expect(EventLogger).to receive(:log).with("incorrect mailing address", archived_intake.id)
+#         post :update, params: {
+#           mailing_address_validation_form: {selected_address: archived_intake.fake_address_1, addresses: archived_intake.address_challenge_set}
+#         }
+#         expect(assigns(:form)).not_to be_valid
+#         expect(session[:mailing_verified]).to eq(nil)
+#         expect(archived_intake.permanently_locked_at).to be_present
+#         expect(response).to redirect_to(knock_out_path)
+#       end
+#     end
+#
+#     context "without a chosen address" do
+#       it "re-renders the edit template" do
+#         post :update, params: {}
+#         expect(assigns(:form)).not_to be_valid
+#         expect(response).to render_template(:edit)
+#       end
+#     end
+#   end
+# end

--- a/spec/controllers/pdf_controller_spec.rb
+++ b/spec/controllers/pdf_controller_spec.rb
@@ -1,51 +1,51 @@
-require "rails_helper"
-
-RSpec.describe PdfController, type: :controller do
-  let(:email_address) { "test@example.com" }
-  let!(:archived_intake) { create(:state_file_archived_intake, state_code: "NY", mailing_state: "NY", email_address: email_address) }
-  let(:valid_verification_code) { "123456" }
-  let(:invalid_verification_code) { "654321" }
-
-  before do
-    allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-    allow(I18n).to receive(:locale).and_return(:en)
-    session[:email_address] = true
-    session[:code_verified] = true
-    session[:ssn_verified] = true
-    session[:mailing_verified] = true
-    sign_in_archived_intake(archived_intake)
-    allow(EventLogger).to receive(:log)
-  end
-
-  describe "GET #index" do
-    it_behaves_like "archived intake locked", action: :index, method: :get
-    it_behaves_like "an authenticated archived intake controller", :get, :index
-
-    context "by default" do
-      it "renders" do
-        expect(EventLogger).to receive(:log).with("issued pdf download link", archived_intake.id)
-        get :index
-        expect(assigns(:state)).to eq("New York")
-        expect(response).to render_template(:index)
-      end
-    end
-  end
-
-  describe "POST #log_and_redirect" do
-    let(:pdf_url) { "https://example.com/test.pdf" }
-    let(:mock_pdf) { spy }
-
-    before do
-      allow_any_instance_of(StateFileArchivedIntake).to receive(:submission_pdf).and_return(mock_pdf)
-      allow(mock_pdf).to receive(:url).and_return(pdf_url)
-    end
-
-    it_behaves_like "an authenticated archived intake controller", :post, :log_and_redirect
-
-    it "logs the access event and redirects to the provided pdf_url" do
-      expect(EventLogger).to receive(:log).with("client pdf download click", archived_intake.id)
-      post :log_and_redirect
-      expect(response).to redirect_to(pdf_url)
-    end
-  end
-end
+# require "rails_helper"
+#
+# RSpec.describe PdfController, type: :controller do
+#   let(:email_address) { "test@example.com" }
+#   let!(:archived_intake) { create(:state_file_archived_intake, state_code: "NY", mailing_state: "NY", email_address: email_address) }
+#   let(:valid_verification_code) { "123456" }
+#   let(:invalid_verification_code) { "654321" }
+#
+#   before do
+#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
+#     allow(I18n).to receive(:locale).and_return(:en)
+#     session[:email_address] = true
+#     session[:code_verified] = true
+#     session[:ssn_verified] = true
+#     session[:mailing_verified] = true
+#     sign_in_archived_intake(archived_intake)
+#     allow(EventLogger).to receive(:log)
+#   end
+#
+#   describe "GET #index" do
+#     it_behaves_like "archived intake locked", action: :index, method: :get
+#     it_behaves_like "an authenticated archived intake controller", :get, :index
+#
+#     context "by default" do
+#       it "renders" do
+#         expect(EventLogger).to receive(:log).with("issued pdf download link", archived_intake.id)
+#         get :index
+#         expect(assigns(:state)).to eq("New York")
+#         expect(response).to render_template(:index)
+#       end
+#     end
+#   end
+#
+#   describe "POST #log_and_redirect" do
+#     let(:pdf_url) { "https://example.com/test.pdf" }
+#     let(:mock_pdf) { spy }
+#
+#     before do
+#       allow_any_instance_of(StateFileArchivedIntake).to receive(:submission_pdf).and_return(mock_pdf)
+#       allow(mock_pdf).to receive(:url).and_return(pdf_url)
+#     end
+#
+#     it_behaves_like "an authenticated archived intake controller", :post, :log_and_redirect
+#
+#     it "logs the access event and redirects to the provided pdf_url" do
+#       expect(EventLogger).to receive(:log).with("client pdf download click", archived_intake.id)
+#       post :log_and_redirect
+#       expect(response).to redirect_to(pdf_url)
+#     end
+#   end
+# end

--- a/spec/controllers/pdf_controller_spec.rb
+++ b/spec/controllers/pdf_controller_spec.rb
@@ -1,51 +1,68 @@
-# require "rails_helper"
-#
-# RSpec.describe PdfController, type: :controller do
-#   let(:email_address) { "test@example.com" }
-#   let!(:archived_intake) { create(:state_file_archived_intake, state_code: "NY", mailing_state: "NY", email_address: email_address) }
-#   let(:valid_verification_code) { "123456" }
-#   let(:invalid_verification_code) { "654321" }
-#
-#   before do
-#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-#     allow(I18n).to receive(:locale).and_return(:en)
-#     session[:email_address] = true
-#     session[:code_verified] = true
-#     session[:ssn_verified] = true
-#     session[:mailing_verified] = true
-#     sign_in_archived_intake(archived_intake)
-#     allow(EventLogger).to receive(:log)
-#   end
-#
-#   describe "GET #index" do
-#     it_behaves_like "archived intake locked", action: :index, method: :get
-#     it_behaves_like "an authenticated archived intake controller", :get, :index
-#
-#     context "by default" do
-#       it "renders" do
-#         expect(EventLogger).to receive(:log).with("issued pdf download link", archived_intake.id)
-#         get :index
-#         expect(assigns(:state)).to eq("New York")
-#         expect(response).to render_template(:index)
-#       end
-#     end
-#   end
-#
-#   describe "POST #log_and_redirect" do
-#     let(:pdf_url) { "https://example.com/test.pdf" }
-#     let(:mock_pdf) { spy }
-#
-#     before do
-#       allow_any_instance_of(StateFileArchivedIntake).to receive(:submission_pdf).and_return(mock_pdf)
-#       allow(mock_pdf).to receive(:url).and_return(pdf_url)
-#     end
-#
-#     it_behaves_like "an authenticated archived intake controller", :post, :log_and_redirect
-#
-#     it "logs the access event and redirects to the provided pdf_url" do
-#       expect(EventLogger).to receive(:log).with("client pdf download click", archived_intake.id)
-#       post :log_and_redirect
-#       expect(response).to redirect_to(pdf_url)
-#     end
-#   end
-# end
+require "rails_helper"
+
+RSpec.describe PdfController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  let(:email_address) { "test@example.com" }
+  let!(:archived_intake) do
+    create(:state_file_archived_intake,
+      state_code: "NY",
+      mailing_state: "NY",
+      email_address: email_address)
+  end
+  let(:valid_verification_code) { "123456" }
+  let(:invalid_verification_code) { "654321" }
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+    sign_in archived_intake
+
+    session[:code_verified] = true
+    session[:ssn_verified] = true
+    session[:mailing_verified] = true
+    session[:year_selected] = 2024
+
+    allow(EventLogger).to receive(:log)
+  end
+
+  describe "GET #index" do
+    it_behaves_like "archived intake locked", action: :index, method: :get
+    it_behaves_like "an authenticated archived intake controller", :get, :index
+
+    context "by default" do
+      it "renders and sets @state/@year and logs 'issued pdf download link'" do
+        expect(EventLogger).to receive(:log).with("issued pdf download link", archived_intake.id)
+
+        get :index
+
+        expect(assigns(:state)).to eq("New York")
+        expect(assigns(:year)).to eq(2024)
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+
+  describe "POST #log_and_redirect" do
+    let(:pdf_url) { "https://example.com/test.pdf" }
+    let(:mock_pdf) { spy("pdf") }
+
+    before do
+      allow_any_instance_of(StateFileArchivedIntake)
+        .to receive(:submission_pdf)
+        .and_return(mock_pdf)
+      allow(mock_pdf)
+        .to receive(:url)
+        .and_return(pdf_url)
+    end
+
+    it_behaves_like "an authenticated archived intake controller", :post, :log_and_redirect
+
+    it "logs the access event and redirects to the provided pdf_url" do
+      expect(EventLogger).to receive(:log).with("client pdf download click", archived_intake.id)
+
+      post :log_and_redirect
+
+      expect(response).to redirect_to(pdf_url)
+    end
+  end
+end

--- a/spec/controllers/phone_number_controller_spec.rb
+++ b/spec/controllers/phone_number_controller_spec.rb
@@ -1,90 +1,90 @@
-require "rails_helper"
-
-RSpec.describe PhoneNumberController, type: :controller do
-  describe "GET #edit" do
-    it "renders the edit template with a new PhoneNumberForm" do
-      get :edit
-
-      expect(assigns(:form)).to be_a(PhoneNumberForm)
-      expect(response).to render_template(:edit)
-    end
-  end
-
-  describe "POST #update" do
-    let(:valid_phone_number) { "+14153334444" }
-    let(:invalid_phone_number) { "21122112" }
-
-    context "when the form is valid" do
-      before do
-        session[:year_selected] = "2023"
-      end
-      context "and an archived intake exists with the phone number" do
-        let!(:archived_intake) { create :state_file_archived_intake, phone_number: valid_phone_number, tax_year: "2023" }
-        # TODO update this test with logging and the proper redirects https://codeforamerica.atlassian.net/browse/FYST-2088
-        it "creates a request, updates the session, redirects to the verification code path and calls sign in with the existing intake" do
-          expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
-          post :update, params: {
-            phone_number_form: {phone_number: valid_phone_number}
-          }
-          expect(assigns(:form)).to be_valid
-          active_archived_intake = controller.send(:current_archived_intake)
-
-          expect(active_archived_intake.phone_number).to eq(valid_phone_number)
-          expect(active_archived_intake.hashed_ssn).to eq(archived_intake.hashed_ssn)
-          expect(active_archived_intake.id).to eq(archived_intake.id)
-
-          expect(session[:ssn_verified]).to be(false)
-          expect(session[:mailing_verified]).to be(false)
-          expect(session[:code_verified]).to be(false)
-          expect(session[:phone_number]).to eq(valid_phone_number)
-
-          expect(response).to redirect_to(edit_verification_code_path)
-        end
-      end
-
-      context "and an archived intake does not exist with the phone number" do
-        it "creates a new archived intake without a ssn or address, and redirects to the verification code page and calls sign in with the existing intake" do
-          expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
-          post :update, params: {
-            phone_number_form: {phone_number: valid_phone_number}
-          }
-          expect(assigns(:form)).to be_valid
-
-          active_archived_intake = controller.send(:current_archived_intake)
-          expect(active_archived_intake.phone_number).to eq(valid_phone_number)
-          expect(active_archived_intake.hashed_ssn).to eq(nil)
-          expect(active_archived_intake.full_address).to eq("")
-          expect(active_archived_intake.contact_preference).to eq("text")
-
-          expect(response).to redirect_to(edit_verification_code_path)
-        end
-
-        it "resets verification session variables and sets phone number" do
-          post :update, params: {
-            phone_number_form: {phone_number: valid_phone_number}
-          }
-
-          expect(assigns(:form)).to be_valid
-
-          expect(session[:ssn_verified]).to be(false)
-          expect(session[:mailing_verified]).to be(false)
-          expect(session[:code_verified]).to be(false)
-
-          expect(session[:phone_number]).to eq(valid_phone_number)
-        end
-      end
-    end
-
-    context "when the form is invalid" do
-      it "renders the edit template" do
-        post :update, params: {
-          phone_number_form: {phone_number: invalid_phone_number}
-        }
-
-        expect(assigns(:form)).not_to be_valid
-
-        expect(response).to render_template(:edit)
-      end
-    end
-  end
-end
+# require "rails_helper"
+#
+# RSpec.describe PhoneNumberController, type: :controller do
+#   describe "GET #edit" do
+#     it "renders the edit template with a new PhoneNumberForm" do
+#       get :edit
+#
+#       expect(assigns(:form)).to be_a(PhoneNumberForm)
+#       expect(response).to render_template(:edit)
+#     end
+#   end
+#
+#   describe "POST #update" do
+#     let(:valid_phone_number) { "+14153334444" }
+#     let(:invalid_phone_number) { "21122112" }
+#
+#     context "when the form is valid" do
+#       before do
+#         session[:year_selected] = "2023"
+#       end
+#       context "and an archived intake exists with the phone number" do
+#         let!(:archived_intake) { create :state_file_archived_intake, phone_number: valid_phone_number, tax_year: "2023" }
+#         # TODO update this test with logging and the proper redirects https://codeforamerica.atlassian.net/browse/FYST-2088
+#         it "creates a request, updates the session, redirects to the verification code path and calls sign in with the existing intake" do
+#           expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
+#           post :update, params: {
+#             phone_number_form: {phone_number: valid_phone_number}
+#           }
+#           expect(assigns(:form)).to be_valid
+#           active_archived_intake = controller.send(:current_archived_intake)
+#
+#           expect(active_archived_intake.phone_number).to eq(valid_phone_number)
+#           expect(active_archived_intake.hashed_ssn).to eq(archived_intake.hashed_ssn)
+#           expect(active_archived_intake.id).to eq(archived_intake.id)
+#
+#           expect(session[:ssn_verified]).to be(false)
+#           expect(session[:mailing_verified]).to be(false)
+#           expect(session[:code_verified]).to be(false)
+#           expect(session[:phone_number]).to eq(valid_phone_number)
+#
+#           expect(response).to redirect_to(edit_verification_code_path)
+#         end
+#       end
+#
+#       context "and an archived intake does not exist with the phone number" do
+#         it "creates a new archived intake without a ssn or address, and redirects to the verification code page and calls sign in with the existing intake" do
+#           expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
+#           post :update, params: {
+#             phone_number_form: {phone_number: valid_phone_number}
+#           }
+#           expect(assigns(:form)).to be_valid
+#
+#           active_archived_intake = controller.send(:current_archived_intake)
+#           expect(active_archived_intake.phone_number).to eq(valid_phone_number)
+#           expect(active_archived_intake.hashed_ssn).to eq(nil)
+#           expect(active_archived_intake.full_address).to eq("")
+#           expect(active_archived_intake.contact_preference).to eq("text")
+#
+#           expect(response).to redirect_to(edit_verification_code_path)
+#         end
+#
+#         it "resets verification session variables and sets phone number" do
+#           post :update, params: {
+#             phone_number_form: {phone_number: valid_phone_number}
+#           }
+#
+#           expect(assigns(:form)).to be_valid
+#
+#           expect(session[:ssn_verified]).to be(false)
+#           expect(session[:mailing_verified]).to be(false)
+#           expect(session[:code_verified]).to be(false)
+#
+#           expect(session[:phone_number]).to eq(valid_phone_number)
+#         end
+#       end
+#     end
+#
+#     context "when the form is invalid" do
+#       it "renders the edit template" do
+#         post :update, params: {
+#           phone_number_form: {phone_number: invalid_phone_number}
+#         }
+#
+#         expect(assigns(:form)).not_to be_valid
+#
+#         expect(response).to render_template(:edit)
+#       end
+#     end
+#   end
+# end

--- a/spec/controllers/phone_number_controller_spec.rb
+++ b/spec/controllers/phone_number_controller_spec.rb
@@ -1,90 +1,86 @@
-# require "rails_helper"
-#
-# RSpec.describe PhoneNumberController, type: :controller do
-#   describe "GET #edit" do
-#     it "renders the edit template with a new PhoneNumberForm" do
-#       get :edit
-#
-#       expect(assigns(:form)).to be_a(PhoneNumberForm)
-#       expect(response).to render_template(:edit)
-#     end
-#   end
-#
-#   describe "POST #update" do
-#     let(:valid_phone_number) { "+14153334444" }
-#     let(:invalid_phone_number) { "21122112" }
-#
-#     context "when the form is valid" do
-#       before do
-#         session[:year_selected] = "2023"
-#       end
-#       context "and an archived intake exists with the phone number" do
-#         let!(:archived_intake) { create :state_file_archived_intake, phone_number: valid_phone_number, tax_year: "2023" }
-#         # TODO update this test with logging and the proper redirects https://codeforamerica.atlassian.net/browse/FYST-2088
-#         it "creates a request, updates the session, redirects to the verification code path and calls sign in with the existing intake" do
-#           expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
-#           post :update, params: {
-#             phone_number_form: {phone_number: valid_phone_number}
-#           }
-#           expect(assigns(:form)).to be_valid
-#           active_archived_intake = controller.send(:current_archived_intake)
-#
-#           expect(active_archived_intake.phone_number).to eq(valid_phone_number)
-#           expect(active_archived_intake.hashed_ssn).to eq(archived_intake.hashed_ssn)
-#           expect(active_archived_intake.id).to eq(archived_intake.id)
-#
-#           expect(session[:ssn_verified]).to be(false)
-#           expect(session[:mailing_verified]).to be(false)
-#           expect(session[:code_verified]).to be(false)
-#           expect(session[:phone_number]).to eq(valid_phone_number)
-#
-#           expect(response).to redirect_to(edit_verification_code_path)
-#         end
-#       end
-#
-#       context "and an archived intake does not exist with the phone number" do
-#         it "creates a new archived intake without a ssn or address, and redirects to the verification code page and calls sign in with the existing intake" do
-#           expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
-#           post :update, params: {
-#             phone_number_form: {phone_number: valid_phone_number}
-#           }
-#           expect(assigns(:form)).to be_valid
-#
-#           active_archived_intake = controller.send(:current_archived_intake)
-#           expect(active_archived_intake.phone_number).to eq(valid_phone_number)
-#           expect(active_archived_intake.hashed_ssn).to eq(nil)
-#           expect(active_archived_intake.full_address).to eq("")
-#           expect(active_archived_intake.contact_preference).to eq("text")
-#
-#           expect(response).to redirect_to(edit_verification_code_path)
-#         end
-#
-#         it "resets verification session variables and sets phone number" do
-#           post :update, params: {
-#             phone_number_form: {phone_number: valid_phone_number}
-#           }
-#
-#           expect(assigns(:form)).to be_valid
-#
-#           expect(session[:ssn_verified]).to be(false)
-#           expect(session[:mailing_verified]).to be(false)
-#           expect(session[:code_verified]).to be(false)
-#
-#           expect(session[:phone_number]).to eq(valid_phone_number)
-#         end
-#       end
-#     end
-#
-#     context "when the form is invalid" do
-#       it "renders the edit template" do
-#         post :update, params: {
-#           phone_number_form: {phone_number: invalid_phone_number}
-#         }
-#
-#         expect(assigns(:form)).not_to be_valid
-#
-#         expect(response).to render_template(:edit)
-#       end
-#     end
-#   end
-# end
+require "rails_helper"
+
+RSpec.describe PhoneNumberController, type: :controller do
+  describe "GET #edit" do
+    it "renders the edit template with a new PhoneNumberForm" do
+      get :edit
+
+      expect(assigns(:form)).to be_a(PhoneNumberForm)
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe "POST #update" do
+    let(:valid_phone_number) { "+14153334444" }
+    let(:invalid_phone_number) { "21122112" }
+
+    context "when the form is valid" do
+      before do
+        session[:year_selected] = "2023"
+      end
+      context "and an archived intake exists with the phone number" do
+        let!(:archived_intake) { create :state_file_archived_intake, phone_number: valid_phone_number, tax_year: "2023" }
+        it "creates a request, updates the session, redirects to the verification code path and calls sign in with the existing intake" do
+          expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
+          post :update, params: {
+            phone_number_form: {phone_number: valid_phone_number}
+          }
+          expect(assigns(:form)).to be_valid
+          active_archived_intake = controller.current_state_file_archived_intake
+
+          expect(active_archived_intake.phone_number).to eq(valid_phone_number)
+          expect(active_archived_intake.hashed_ssn).to eq(archived_intake.hashed_ssn)
+          expect(active_archived_intake.id).to eq(archived_intake.id)
+
+          expect(session[:ssn_verified]).to be(false)
+          expect(session[:mailing_verified]).to be(false)
+          expect(session[:code_verified]).to be(false)
+
+          expect(response).to redirect_to(edit_verification_code_path)
+        end
+      end
+
+      context "and an archived intake does not exist with the phone number" do
+        it "creates a new archived intake without a ssn or address, and redirects to the verification code page and calls sign in with the existing intake" do
+          expect(controller).to receive(:sign_in).with(instance_of(StateFileArchivedIntake)).and_call_original
+          post :update, params: {
+            phone_number_form: {phone_number: valid_phone_number}
+          }
+          expect(assigns(:form)).to be_valid
+
+          active_archived_intake = controller.current_state_file_archived_intake
+          expect(active_archived_intake.phone_number).to eq(valid_phone_number)
+          expect(active_archived_intake.hashed_ssn).to eq(nil)
+          expect(active_archived_intake.full_address).to eq("")
+          expect(active_archived_intake.contact_preference).to eq("text")
+
+          expect(response).to redirect_to(edit_verification_code_path)
+        end
+
+        it "resets verification session variables and sets phone number" do
+          post :update, params: {
+            phone_number_form: {phone_number: valid_phone_number}
+          }
+
+          expect(assigns(:form)).to be_valid
+
+          expect(session[:ssn_verified]).to be(false)
+          expect(session[:mailing_verified]).to be(false)
+          expect(session[:code_verified]).to be(false)
+        end
+      end
+    end
+
+    context "when the form is invalid" do
+      it "renders the edit template" do
+        post :update, params: {
+          phone_number_form: {phone_number: invalid_phone_number}
+        }
+
+        expect(assigns(:form)).not_to be_valid
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/verification_code_controller_spec.rb
+++ b/spec/controllers/verification_code_controller_spec.rb
@@ -1,173 +1,180 @@
-# require "rails_helper"
-#
-# RSpec.describe VerificationCodeController, type: :controller do
-#   let(:email_address) { "test@example.com" }
-#   let!(:archived_intake) { create(:state_file_archived_intake, email_address: email_address, contact_preference: contact_preference, phone_number: phone_number) }
-#   let(:contact_preference) { "email" }
-#   let(:phone_number) { nil }
-#   let(:valid_verification_code) { "123456" }
-#   let(:invalid_verification_code) { "654321" }
-#
-#   before do
-#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-#     allow(I18n).to receive(:locale).and_return(:en)
-#     sign_in_archived_intake(archived_intake)
-#     allow(EventLogger).to receive(:log)
-#   end
-#
-#   describe "GET #edit" do
-#     it_behaves_like "archived intake locked", action: :edit, method: :get
-#     it_behaves_like "an authenticated archived intake controller", :get, :edit
-#
-#     context "when the request is not locked" do
-#       before do
-#         allow(archived_intake).to receive(:access_locked?).and_return(false)
-#       end
-#
-#       context "when contact preference is email" do
-#         let(:contact_preference) { "email" }
-#
-#         it "renders the edit template with a new VerificationCodeForm and queues a job" do
-#           expect(EventLogger).to receive(:log).with("issued email challenge", archived_intake.id)
-#
-#           expect {
-#             get :edit
-#           }.to have_enqueued_job(EmailVerificationCodeJob).with(
-#             email_address: email_address,
-#             locale: :en
-#           )
-#
-#           expect(assigns(:form)).to be_a(VerificationCodeForm)
-#           expect(assigns(:email_address)).to eq(email_address)
-#           expect(response).to render_template(:edit)
-#         end
-#       end
-#
-#       context "when contact preference is text message" do
-#         let(:contact_preference) { "text" }
-#         let(:phone_number) { "5038675309" }
-#
-#         it "renders the edit template with a new VerificationCodeForm and queues a job" do
-#           expect(EventLogger).to receive(:log).with("issued text challenge", archived_intake.id)
-#
-#           expect {
-#             get :edit
-#           }.to have_enqueued_job(TextMessageVerificationCodeJob).with(
-#             phone_number: phone_number,
-#             locale: :en
-#           )
-#
-#           expect(assigns(:form)).to be_a(VerificationCodeForm)
-#           expect(assigns(:phone_number)).to eq(phone_number)
-#           expect(response).to render_template(:edit)
-#         end
-#       end
-#     end
-#   end
-#
-#   describe "POST #update" do
-#     it_behaves_like "an authenticated archived intake controller", :post, :update
-#
-#     context "with a valid verification code" do
-#       before do
-#         allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(true)
-#       end
-#
-#       context "email preference" do
-#         let(:contact_preference) { "email" }
-#
-#         it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
-#           expect(EventLogger).to receive(:log).with("correct email code", archived_intake.id).ordered
-#           expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
-#
-#           post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
-#
-#           expect(session[:code_verified]).to eq(true)
-#           expect(archived_intake.failed_attempts).to eq(0)
-#           expect(response).to redirect_to(edit_identification_number_path)
-#         end
-#       end
-#
-#       context "text preference" do
-#         let(:contact_preference) { "text" }
-#         let(:phone_number) { "5038675309" }
-#
-#         it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
-#           expect(EventLogger).to receive(:log).with("correct text challenge", archived_intake.id).ordered
-#           expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
-#
-#           post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
-#
-#           expect(session[:code_verified]).to eq(true)
-#           expect(archived_intake.failed_attempts).to eq(0)
-#           expect(response).to redirect_to(edit_identification_number_path)
-#         end
-#       end
-#     end
-#
-#     context "with an invalid verification code" do
-#       before do
-#         allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(false)
-#       end
-#
-#       context "email preference" do
-#         let(:contact_preference) { "email" }
-#
-#         it "increments failed_attempts and re-renders edit on first failed attempt" do
-#           expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id)
-#
-#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-#
-#           expect(session[:code_verified]).to eq(nil)
-#           expect(archived_intake.reload.failed_attempts).to eq(1)
-#           expect(assigns(:form)).to be_a(VerificationCodeForm)
-#           expect(response).to render_template(:edit)
-#         end
-#
-#         it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
-#           archived_intake.update!(failed_attempts: 1)
-#
-#           expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id).ordered
-#           expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
-#
-#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-#
-#           expect(session[:code_verified]).to eq(nil)
-#           expect(archived_intake.reload.failed_attempts).to eq(2)
-#           expect(archived_intake.reload.access_locked?).to be_truthy
-#           expect(response).to redirect_to(knock_out_path)
-#         end
-#       end
-#
-#       context "text preference" do
-#         let(:contact_preference) { "text" }
-#         let(:phone_number) { "5038675309" }
-#
-#         it "increments failed_attempts and re-renders edit on first failed attempt" do
-#           expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id)
-#
-#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-#
-#           expect(session[:code_verified]).to eq(nil)
-#           expect(archived_intake.reload.failed_attempts).to eq(1)
-#           expect(assigns(:form)).to be_a(VerificationCodeForm)
-#           expect(response).to render_template(:edit)
-#         end
-#
-#         it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
-#           archived_intake.update!(failed_attempts: 1)
-#
-#           expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id).ordered
-#           expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
-#
-#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-#
-#           expect(session[:code_verified]).to eq(nil)
-#           expect(archived_intake.reload.failed_attempts).to eq(2)
-#           expect(archived_intake.reload.access_locked?).to be_truthy
-#           expect(response).to redirect_to(knock_out_path)
-#         end
-#       end
-#     end
-#   end
-# end
+require "rails_helper"
+
+RSpec.describe VerificationCodeController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  include ActiveJob::TestHelper
+
+  let(:email_address) { "test@example.com" }
+  let(:contact_preference) { "email" }
+  let(:phone_number) { nil }
+  let!(:archived_intake) do
+    create(:state_file_archived_intake,
+      email_address: email_address,
+      contact_preference: contact_preference,
+      phone_number: phone_number)
+  end
+
+  let(:valid_verification_code) { "123456" }
+  let(:invalid_verification_code) { "654321" }
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+    sign_in archived_intake
+
+    allow(EventLogger).to receive(:log)
+  end
+
+  describe "GET #edit" do
+    it_behaves_like "archived intake locked", action: :edit, method: :get
+    it_behaves_like "an authenticated archived intake controller", :get, :edit
+
+    context "when the request is not locked" do
+      before { allow(archived_intake).to receive(:access_locked?).and_return(false) }
+
+      context "when contact preference is email" do
+        let(:contact_preference) { "email" }
+
+        it "renders :edit with a VerificationCodeForm and enqueues EmailVerificationCodeJob" do
+          expect(EventLogger).to receive(:log).with("issued email challenge", archived_intake.id)
+
+          expect {
+            get :edit
+          }.to have_enqueued_job(EmailVerificationCodeJob).with(
+            email_address: email_address,
+            locale: :en
+          )
+
+          expect(assigns(:form)).to be_a(VerificationCodeForm)
+          expect(assigns(:email_address)).to eq(email_address)
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context "when contact preference is text message" do
+        let(:contact_preference) { "text" }
+        let(:phone_number) { "5038675309" }
+
+        it "renders :edit with a VerificationCodeForm and enqueues TextMessageVerificationCodeJob" do
+          expect(EventLogger).to receive(:log).with("issued text challenge", archived_intake.id)
+
+          expect {
+            get :edit
+          }.to have_enqueued_job(TextMessageVerificationCodeJob).with(
+            phone_number: phone_number,
+            locale: :en
+          )
+
+          expect(assigns(:form)).to be_a(VerificationCodeForm)
+          expect(assigns(:phone_number)).to eq(phone_number)
+          expect(response).to render_template(:edit)
+        end
+      end
+    end
+  end
+
+  describe "POST #update" do
+    it_behaves_like "an authenticated archived intake controller", :post, :update
+
+    context "with a valid verification code" do
+      before do
+        allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(true)
+      end
+
+      context "email preference" do
+        let(:contact_preference) { "email" }
+
+        it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
+          expect(EventLogger).to receive(:log).with("correct email code", archived_intake.id).ordered
+          expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
+
+          post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
+
+          expect(session[:code_verified]).to eq(true)
+          expect(archived_intake.reload.failed_attempts).to eq(0)
+          expect(response).to redirect_to(edit_identification_number_path)
+        end
+      end
+
+      context "text preference" do
+        let(:contact_preference) { "text" }
+        let(:phone_number) { "5038675309" }
+
+        it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
+          expect(EventLogger).to receive(:log).with("correct text challenge", archived_intake.id).ordered
+          expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
+
+          post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
+
+          expect(session[:code_verified]).to eq(true)
+          expect(archived_intake.reload.failed_attempts).to eq(0)
+          expect(response).to redirect_to(edit_identification_number_path)
+        end
+      end
+    end
+
+    context "with an invalid verification code" do
+      before do
+        allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(false)
+      end
+
+      context "email preference" do
+        let(:contact_preference) { "email" }
+
+        it "increments failed_attempts and re-renders edit on first failed attempt" do
+          expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id)
+
+          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+
+          expect(session[:code_verified]).to be_nil
+          expect(archived_intake.reload.failed_attempts).to eq(1)
+          expect(assigns(:form)).to be_a(VerificationCodeForm)
+          expect(response).to render_template(:edit)
+        end
+
+        it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
+          archived_intake.update!(failed_attempts: 1)
+
+          expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id).ordered
+          expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
+
+          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+
+          expect(session[:code_verified]).to be_nil
+          expect(archived_intake.reload.failed_attempts).to eq(2)
+          expect(archived_intake.reload.access_locked?).to be(true)
+          expect(response).to redirect_to(knock_out_path)
+        end
+      end
+
+      context "text preference" do
+        let(:contact_preference) { "text" }
+        let(:phone_number) { "5038675309" }
+
+        it "increments failed_attempts and re-renders edit on first failed attempt" do
+          expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id)
+
+          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+
+          expect(session[:code_verified]).to be_nil
+          expect(archived_intake.reload.failed_attempts).to eq(1)
+          expect(assigns(:form)).to be_a(VerificationCodeForm)
+          expect(response).to render_template(:edit)
+        end
+
+        it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
+          archived_intake.update!(failed_attempts: 1)
+
+          expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id).ordered
+          expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
+
+          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+
+          expect(session[:code_verified]).to be_nil
+          expect(archived_intake.reload.failed_attempts).to eq(2)
+          expect(archived_intake.reload.access_locked?).to be(true)
+          expect(response).to redirect_to(knock_out_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/verification_code_controller_spec.rb
+++ b/spec/controllers/verification_code_controller_spec.rb
@@ -1,173 +1,173 @@
-require "rails_helper"
-
-RSpec.describe VerificationCodeController, type: :controller do
-  let(:email_address) { "test@example.com" }
-  let!(:archived_intake) { create(:state_file_archived_intake, email_address: email_address, contact_preference: contact_preference, phone_number: phone_number) }
-  let(:contact_preference) { "email" }
-  let(:phone_number) { nil }
-  let(:valid_verification_code) { "123456" }
-  let(:invalid_verification_code) { "654321" }
-
-  before do
-    allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
-    allow(I18n).to receive(:locale).and_return(:en)
-    sign_in_archived_intake(archived_intake)
-    allow(EventLogger).to receive(:log)
-  end
-
-  describe "GET #edit" do
-    it_behaves_like "archived intake locked", action: :edit, method: :get
-    it_behaves_like "an authenticated archived intake controller", :get, :edit
-
-    context "when the request is not locked" do
-      before do
-        allow(archived_intake).to receive(:access_locked?).and_return(false)
-      end
-
-      context "when contact preference is email" do
-        let(:contact_preference) { "email" }
-
-        it "renders the edit template with a new VerificationCodeForm and queues a job" do
-          expect(EventLogger).to receive(:log).with("issued email challenge", archived_intake.id)
-
-          expect {
-            get :edit
-          }.to have_enqueued_job(EmailVerificationCodeJob).with(
-            email_address: email_address,
-            locale: :en
-          )
-
-          expect(assigns(:form)).to be_a(VerificationCodeForm)
-          expect(assigns(:email_address)).to eq(email_address)
-          expect(response).to render_template(:edit)
-        end
-      end
-
-      context "when contact preference is text message" do
-        let(:contact_preference) { "text" }
-        let(:phone_number) { "5038675309" }
-
-        it "renders the edit template with a new VerificationCodeForm and queues a job" do
-          expect(EventLogger).to receive(:log).with("issued text challenge", archived_intake.id)
-
-          expect {
-            get :edit
-          }.to have_enqueued_job(TextMessageVerificationCodeJob).with(
-            phone_number: phone_number,
-            locale: :en
-          )
-
-          expect(assigns(:form)).to be_a(VerificationCodeForm)
-          expect(assigns(:phone_number)).to eq(phone_number)
-          expect(response).to render_template(:edit)
-        end
-      end
-    end
-  end
-
-  describe "POST #update" do
-    it_behaves_like "an authenticated archived intake controller", :post, :update
-
-    context "with a valid verification code" do
-      before do
-        allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(true)
-      end
-
-      context "email preference" do
-        let(:contact_preference) { "email" }
-
-        it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
-          expect(EventLogger).to receive(:log).with("correct email code", archived_intake.id).ordered
-          expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
-
-          post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
-
-          expect(session[:code_verified]).to eq(true)
-          expect(archived_intake.failed_attempts).to eq(0)
-          expect(response).to redirect_to(edit_identification_number_path)
-        end
-      end
-
-      context "text preference" do
-        let(:contact_preference) { "text" }
-        let(:phone_number) { "5038675309" }
-
-        it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
-          expect(EventLogger).to receive(:log).with("correct text challenge", archived_intake.id).ordered
-          expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
-
-          post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
-
-          expect(session[:code_verified]).to eq(true)
-          expect(archived_intake.failed_attempts).to eq(0)
-          expect(response).to redirect_to(edit_identification_number_path)
-        end
-      end
-    end
-
-    context "with an invalid verification code" do
-      before do
-        allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(false)
-      end
-
-      context "email preference" do
-        let(:contact_preference) { "email" }
-
-        it "increments failed_attempts and re-renders edit on first failed attempt" do
-          expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id)
-
-          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-
-          expect(session[:code_verified]).to eq(nil)
-          expect(archived_intake.reload.failed_attempts).to eq(1)
-          expect(assigns(:form)).to be_a(VerificationCodeForm)
-          expect(response).to render_template(:edit)
-        end
-
-        it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
-          archived_intake.update!(failed_attempts: 1)
-
-          expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id).ordered
-          expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
-
-          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-
-          expect(session[:code_verified]).to eq(nil)
-          expect(archived_intake.reload.failed_attempts).to eq(2)
-          expect(archived_intake.reload.access_locked?).to be_truthy
-          expect(response).to redirect_to(knock_out_path)
-        end
-      end
-
-      context "text preference" do
-        let(:contact_preference) { "text" }
-        let(:phone_number) { "5038675309" }
-
-        it "increments failed_attempts and re-renders edit on first failed attempt" do
-          expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id)
-
-          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-
-          expect(session[:code_verified]).to eq(nil)
-          expect(archived_intake.reload.failed_attempts).to eq(1)
-          expect(assigns(:form)).to be_a(VerificationCodeForm)
-          expect(response).to render_template(:edit)
-        end
-
-        it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
-          archived_intake.update!(failed_attempts: 1)
-
-          expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id).ordered
-          expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
-
-          post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
-
-          expect(session[:code_verified]).to eq(nil)
-          expect(archived_intake.reload.failed_attempts).to eq(2)
-          expect(archived_intake.reload.access_locked?).to be_truthy
-          expect(response).to redirect_to(knock_out_path)
-        end
-      end
-    end
-  end
-end
+# require "rails_helper"
+#
+# RSpec.describe VerificationCodeController, type: :controller do
+#   let(:email_address) { "test@example.com" }
+#   let!(:archived_intake) { create(:state_file_archived_intake, email_address: email_address, contact_preference: contact_preference, phone_number: phone_number) }
+#   let(:contact_preference) { "email" }
+#   let(:phone_number) { nil }
+#   let(:valid_verification_code) { "123456" }
+#   let(:invalid_verification_code) { "654321" }
+#
+#   before do
+#     allow(controller).to receive(:current_archived_intake).and_return(archived_intake)
+#     allow(I18n).to receive(:locale).and_return(:en)
+#     sign_in_archived_intake(archived_intake)
+#     allow(EventLogger).to receive(:log)
+#   end
+#
+#   describe "GET #edit" do
+#     it_behaves_like "archived intake locked", action: :edit, method: :get
+#     it_behaves_like "an authenticated archived intake controller", :get, :edit
+#
+#     context "when the request is not locked" do
+#       before do
+#         allow(archived_intake).to receive(:access_locked?).and_return(false)
+#       end
+#
+#       context "when contact preference is email" do
+#         let(:contact_preference) { "email" }
+#
+#         it "renders the edit template with a new VerificationCodeForm and queues a job" do
+#           expect(EventLogger).to receive(:log).with("issued email challenge", archived_intake.id)
+#
+#           expect {
+#             get :edit
+#           }.to have_enqueued_job(EmailVerificationCodeJob).with(
+#             email_address: email_address,
+#             locale: :en
+#           )
+#
+#           expect(assigns(:form)).to be_a(VerificationCodeForm)
+#           expect(assigns(:email_address)).to eq(email_address)
+#           expect(response).to render_template(:edit)
+#         end
+#       end
+#
+#       context "when contact preference is text message" do
+#         let(:contact_preference) { "text" }
+#         let(:phone_number) { "5038675309" }
+#
+#         it "renders the edit template with a new VerificationCodeForm and queues a job" do
+#           expect(EventLogger).to receive(:log).with("issued text challenge", archived_intake.id)
+#
+#           expect {
+#             get :edit
+#           }.to have_enqueued_job(TextMessageVerificationCodeJob).with(
+#             phone_number: phone_number,
+#             locale: :en
+#           )
+#
+#           expect(assigns(:form)).to be_a(VerificationCodeForm)
+#           expect(assigns(:phone_number)).to eq(phone_number)
+#           expect(response).to render_template(:edit)
+#         end
+#       end
+#     end
+#   end
+#
+#   describe "POST #update" do
+#     it_behaves_like "an authenticated archived intake controller", :post, :update
+#
+#     context "with a valid verification code" do
+#       before do
+#         allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(true)
+#       end
+#
+#       context "email preference" do
+#         let(:contact_preference) { "email" }
+#
+#         it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
+#           expect(EventLogger).to receive(:log).with("correct email code", archived_intake.id).ordered
+#           expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
+#
+#           post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
+#
+#           expect(session[:code_verified]).to eq(true)
+#           expect(archived_intake.failed_attempts).to eq(0)
+#           expect(response).to redirect_to(edit_identification_number_path)
+#         end
+#       end
+#
+#       context "text preference" do
+#         let(:contact_preference) { "text" }
+#         let(:phone_number) { "5038675309" }
+#
+#         it "does not increment failed_attempts, logs success, issues ssn challenge, and redirects" do
+#           expect(EventLogger).to receive(:log).with("correct text challenge", archived_intake.id).ordered
+#           expect(EventLogger).to receive(:log).with("issued ssn challenge", archived_intake.id).ordered
+#
+#           post :update, params: {verification_code_form: {verification_code: valid_verification_code}}
+#
+#           expect(session[:code_verified]).to eq(true)
+#           expect(archived_intake.failed_attempts).to eq(0)
+#           expect(response).to redirect_to(edit_identification_number_path)
+#         end
+#       end
+#     end
+#
+#     context "with an invalid verification code" do
+#       before do
+#         allow_any_instance_of(VerificationCodeForm).to receive(:valid?).and_return(false)
+#       end
+#
+#       context "email preference" do
+#         let(:contact_preference) { "email" }
+#
+#         it "increments failed_attempts and re-renders edit on first failed attempt" do
+#           expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id)
+#
+#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+#
+#           expect(session[:code_verified]).to eq(nil)
+#           expect(archived_intake.reload.failed_attempts).to eq(1)
+#           expect(assigns(:form)).to be_a(VerificationCodeForm)
+#           expect(response).to render_template(:edit)
+#         end
+#
+#         it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
+#           archived_intake.update!(failed_attempts: 1)
+#
+#           expect(EventLogger).to receive(:log).with("incorrect email code", archived_intake.id).ordered
+#           expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
+#
+#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+#
+#           expect(session[:code_verified]).to eq(nil)
+#           expect(archived_intake.reload.failed_attempts).to eq(2)
+#           expect(archived_intake.reload.access_locked?).to be_truthy
+#           expect(response).to redirect_to(knock_out_path)
+#         end
+#       end
+#
+#       context "text preference" do
+#         let(:contact_preference) { "text" }
+#         let(:phone_number) { "5038675309" }
+#
+#         it "increments failed_attempts and re-renders edit on first failed attempt" do
+#           expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id)
+#
+#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+#
+#           expect(session[:code_verified]).to eq(nil)
+#           expect(archived_intake.reload.failed_attempts).to eq(1)
+#           expect(assigns(:form)).to be_a(VerificationCodeForm)
+#           expect(response).to render_template(:edit)
+#         end
+#
+#         it "locks the account, logs lockout begin, and redirects after multiple failed attempts" do
+#           archived_intake.update!(failed_attempts: 1)
+#
+#           expect(EventLogger).to receive(:log).with("incorrect text code", archived_intake.id).ordered
+#           expect(EventLogger).to receive(:log).with("client lockout begin", archived_intake.id).ordered
+#
+#           post :update, params: {verification_code_form: {verification_code: invalid_verification_code}}
+#
+#           expect(session[:code_verified]).to eq(nil)
+#           expect(archived_intake.reload.failed_attempts).to eq(2)
+#           expect(archived_intake.reload.access_locked?).to be_truthy
+#           expect(response).to redirect_to(knock_out_path)
+#         end
+#       end
+#     end
+#   end
+# end

--- a/spec/factories/state_file_archived_intakes.rb
+++ b/spec/factories/state_file_archived_intakes.rb
@@ -26,6 +26,7 @@
 FactoryBot.define do
   factory :state_file_archived_intake do
     email_address { "geddy_lee@example.com" }
+    contact_preference { "email" }
     hashed_ssn { "hashed_ssn_value" }
     mailing_apartment { "Apt 1" }
     mailing_city { "Test City" }

--- a/spec/support/shared_examples/is_intake_locked.rb
+++ b/spec/support/shared_examples/is_intake_locked.rb
@@ -1,39 +1,54 @@
 RSpec.shared_examples "archived intake locked" do |action:, method: :get, params: {}|
+  include Devise::Test::ControllerHelpers
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+    allow(controller).to receive(:knock_out_path).and_return("/knock_out")
+  end
+
   context "when there is no archived intake" do
-    before { allow(controller).to receive(:current_archived_intake).and_return(nil) }
+    before do
+      if controller.respond_to?(:authenticate_state_file_archived_intake!)
+        allow(controller).to receive(:authenticate_state_file_archived_intake!).and_return(true)
+      end
+      sign_out :state_file_archived_intake
+    end
 
     it "redirects to verification error page" do
-      send(method, action, params: params)
-      expect(response).to redirect_to(knock_out_path)
+      public_send(method, action, params: params)
+      expect(response).to redirect_to("/knock_out")
     end
   end
 
   context "when the archived intake is locked" do
-    before { allow(controller.current_archived_intake).to receive(:access_locked?).and_return(true) }
+    let!(:locked) { create(:state_file_archived_intake, locked_at: Time.zone.now) }
+
+    before { sign_in locked }
 
     it "redirects to verification error page" do
-      send(method, action, params: params)
-      expect(response).to redirect_to(knock_out_path)
+      public_send(method, action, params: params)
+      expect(response).to redirect_to("/en/knock_out")
     end
   end
 
   context "when the archived intake is permanently locked" do
-    before { allow(controller.current_archived_intake).to receive(:permanently_locked_at).and_return(Time.current) }
+    let!(:permanently_locked_intake) { create(:state_file_archived_intake, permanently_locked_at: Time.zone.now) }
+
+    before { sign_in permanently_locked_intake }
 
     it "redirects to verification error page" do
-      send(method, action, params: params)
-      expect(response).to redirect_to(knock_out_path)
+      public_send(method, action, params: params)
+      expect(response).to redirect_to("/knock_out")
     end
   end
 
   context "when the archived intake is valid and not locked" do
-    before do
-      allow(controller.current_archived_intake).to receive(:access_locked?).and_return(false)
-      allow(controller.current_archived_intake).to receive(:permanently_locked_at).and_return(nil)
-    end
+    let!(:intake) { create(:state_file_archived_intake) }
+
+    before { sign_in intake }
 
     it "does not redirect" do
-      send(method, action, params: params)
+      public_send(method, action, params: params)
       expect(response).not_to be_redirect
     end
   end

--- a/spec/support/shared_examples/session_timeout.rb
+++ b/spec/support/shared_examples/session_timeout.rb
@@ -1,9 +1,13 @@
-# spec/support/shared_examples/authenticated_controller.rb
 RSpec.shared_examples "an authenticated archived intake controller" do |http_method, action|
   include Devise::Test::ControllerHelpers
 
-  let(:intake) { create(:state_file_archived_intake) }
-  let(:timeout_in) { StateFileArchivedIntake.respond_to?(:timeout_in) ? StateFileArchivedIntake.timeout_in : Devise.timeout_in }
+  let(:intake) do
+    request.env["devise.mapping"] = Devise.mappings[:state_file_archived_intake]
+    create(:state_file_archived_intake)
+  end
+  let(:timeout_in) do
+    StateFileArchivedIntake.respond_to?(:timeout_in) ? StateFileArchivedIntake.timeout_in : Devise.timeout_in
+  end
 
   let(:keys_to_clear) { %i[year_selected ssn_verified mailing_verified code_verified email_address phone_number] }
 
@@ -23,7 +27,7 @@ RSpec.shared_examples "an authenticated archived intake controller" do |http_met
 
     public_send(http_method, action, params: {locale: :en})
 
-    expect(response).to redirect_to(root_path(locale: :en))
+    expect(response).to redirect_to(root_path)
     keys_to_clear.each { |k| expect(session[k]).to be_nil }
     expect(session["warden.user.state_file_archived_intake.key"]).to be_nil
   end


### PR DESCRIPTION
## Link to pivotal/JIRA issue
- https://codeforamerica.atlassian.net/browse/FYST-2095
## Is PM acceptance required? (delete one)
- Yes - don't merge until JIRA issue is accepted!

**Reminder**: merge main into this branch and get green tests before merging to main
## What was done?
-A couple of bugs were discovered in end to end testing, primarily locked out users were not directing to the correct place. This happened because we were not using warden when referencing the current logged in intake. Now we are using warden

- much of these changes are replacing the "current_archived_intake" method with the method "current_state_file_archived_intake" which is defined by devise.

- previously "current_archived_intake" found or created a state_file_archived_intake now we have a method " create_and_login_state_file_archived_intake" that creates a state_file_archived_intake and signs it in 

- contact preference  was previously stored in session now we check it bases on the logged in state_file_archived_intake