### PR TITLE
FYST-2343: copy kevin's test showing from gyraffe that we don't use the DNS-lookup validators in validemail2

### DIFF
--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe EmailAddressForm do
     # MX or disposable-domain checks without a security review.
     before do
       allow(Resolv::DNS).to receive(:open)
-                              .and_raise("EmailAddressForm must not perform DNS lookups on submitted email domains")
+        .and_raise("EmailAddressForm must not perform DNS lookups on submitted email domains")
       allow(Resolv::DNS).to receive(:new)
-                              .and_raise("EmailAddressForm must not perform DNS lookups on submitted email domains")
+        .and_raise("EmailAddressForm must not perform DNS lookups on submitted email domains")
     end
 
     it "does not resolve DNS for a well-formed email on an attacker-controlled domain" do

--- a/spec/forms/email_address_form_spec.rb
+++ b/spec/forms/email_address_form_spec.rb
@@ -43,4 +43,33 @@ RSpec.describe EmailAddressForm do
       expect(form.email_address).to eq("test@example.com")
     end
   end
+
+  describe "DNS resolution (security regression)" do
+    # The valid_email2 gem is capable of MX/A record lookups (valid_mx?,
+    # valid_strict_mx?, disposable?), which would let a submitted email
+    # domain trigger outbound DNS queries from the server to an
+    # attacker-controlled nameserver. EmailAddressForm must only use the
+    # gem's format-only check (ValidEmail2::Address#valid?). Do not add
+    # MX or disposable-domain checks without a security review.
+    before do
+      allow(Resolv::DNS).to receive(:open)
+                              .and_raise("EmailAddressForm must not perform DNS lookups on submitted email domains")
+      allow(Resolv::DNS).to receive(:new)
+                              .and_raise("EmailAddressForm must not perform DNS lookups on submitted email domains")
+    end
+
+    it "does not resolve DNS for a well-formed email on an attacker-controlled domain" do
+      form = described_class.new(email_address: "probe@attacker-controlled.example")
+
+      expect { form.valid? }.not_to raise_error
+      expect(form).to be_valid
+    end
+
+    it "does not resolve DNS for a malformed email" do
+      form = described_class.new(email_address: "not-an-email@@bad..domain")
+
+      expect { form.valid? }.not_to raise_error
+      expect(form).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
https://codeforamerica.atlassian.net/browse/FYST-2343

PYA pentest finding:
> The valid_email2 gem performs DNS resolution (MX/A record lookups) on submitted email domains. This allows an attacker to trigger outbound DNS connections from the server to arbitrary attacker-controlled domains, potentially enabling DNS rebinding attacks against internal services.

This PR adds a test showing that we don't use the DNS-lookup-based validations that `valid_email2` includes.